### PR TITLE
feat: Spring Rest Docs 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'org.asciidoctor.jvm.convert'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ subprojects {
     }
 
     dependencies {
+        compileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.0'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+}
+
+allprojects {
+    group = 'com.capturecat'
+    version = '0.0.1-SNAPSHOT'
+    sourceCompatibility = '21'
+
+    repositories {
+        mavenCentral()
+    }
+}
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'org.asciidoctor.jvm.convert'
+
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
+
+    dependencies {
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    }
+
+    bootJar.enabled = false
+    jar.enabled = true
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
+
+    tasks.named('asciidoctor') {
+        dependsOn test
+    }
+}

--- a/capturecat-core/build.gradle
+++ b/capturecat-core/build.gradle
@@ -1,17 +1,23 @@
-bootJar.enabled = true
 jar.enabled = false
 
+bootJar {
+	enabled = true
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
+}
+
 dependencies {
+	testImplementation project(":capturecat-tests:api-docs")
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	testImplementation project(":capturecat-tests:api-docs")
 }

--- a/capturecat-core/build.gradle
+++ b/capturecat-core/build.gradle
@@ -1,32 +1,5 @@
-plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
-}
-
-group = 'com.capturecat'
-version = '0.0.1-SNAPSHOT'
-
-java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
-}
-
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
-repositories {
-	mavenCentral()
-}
-
-ext {
-	set('snippetsDir', file("build/generated-snippets"))
-}
+bootJar.enabled = true
+jar.enabled = false
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -41,14 +14,4 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
-}
-
-tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
 }

--- a/capturecat-core/build.gradle
+++ b/capturecat-core/build.gradle
@@ -6,12 +6,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testImplementation project(":capturecat-tests:api-docs")
 }

--- a/capturecat-core/src/docs/asciidoc/index.adoc
+++ b/capturecat-core/src/docs/asciidoc/index.adoc
@@ -1,0 +1,20 @@
+= 캡쳐캣 API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:snippets: build/generated-snippets
+
+== Introduce
+캡쳐캣 Core API 문서입니다.
+
+== Health API
+=== Health Check Get API
+==== Curl Request
+include::{snippets}/healthCheck/curl-request.adoc[]
+==== Http Response
+include::{snippets}/healthCheck/http-response.adoc[]
+==== Response Fields
+include::{snippets}/healthCheck/response-fields.adoc[]

--- a/capturecat-core/src/main/java/com/capturecat/HealthCheckController.java
+++ b/capturecat-core/src/main/java/com/capturecat/HealthCheckController.java
@@ -1,5 +1,8 @@
 package com.capturecat;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class HealthCheckController {
 
     @GetMapping("/health")
-    public String healthCheck() {
-        return "UP";
+    public Map<String, String> healthCheck() {
+        Map<String, String> response = new HashMap<>();
+        response.put("status", "UP");
+        return response;
     }
 }

--- a/capturecat-core/src/main/java/com/capturecat/config/SecurityConfig.java
+++ b/capturecat-core/src/main/java/com/capturecat/config/SecurityConfig.java
@@ -1,12 +1,13 @@
 package com.capturecat.config;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
@@ -17,7 +18,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/health").permitAll()
+                        .requestMatchers("/health", "/docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/capturecat-core/src/test/java/com/capturecat/HealthCheckControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/HealthCheckControllerTest.java
@@ -1,0 +1,37 @@
+package com.capturecat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.capturecat.test.api.RestDocsTest;
+
+import io.restassured.http.ContentType;
+
+import static com.capturecat.test.api.RestDocsUtil.requestPreprocessor;
+import static com.capturecat.test.api.RestDocsUtil.responsePreprocessor;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+class HealthCheckControllerTest extends RestDocsTest {
+
+    private HealthCheckController healthCheckController;
+
+    @BeforeEach
+    void setUp() {
+        healthCheckController = new HealthCheckController();
+        mockMvc = mockController(healthCheckController);
+    }
+
+    @Test
+    void 헬스_체크를_한다() {
+        given().contentType(ContentType.JSON)
+                .when().get("/health")
+                .then()
+                .status(HttpStatus.OK)
+                .apply(document("healthCheck", requestPreprocessor(), responsePreprocessor(),
+                        responseFields(fieldWithPath("status").type(JsonFieldType.STRING).description("애플리케이션 상태"))));
+    }
+}

--- a/capturecat-tests/api-docs/build.gradle
+++ b/capturecat-tests/api-docs/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compileOnly 'org.springframework.boot:spring-boot-starter-test'
+    compileOnly 'com.fasterxml.jackson.core:jackson-databind'
+    api 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    api 'org.springframework.restdocs:spring-restdocs-restassured'
+    api 'io.rest-assured:spring-mock-mvc'
+}

--- a/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsTest.java
+++ b/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsTest.java
@@ -1,0 +1,84 @@
+package com.capturecat.test.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
+
+/**
+ * Spring Rest Docs 테스트를 위한 공통 기반 클래스입니다.
+ * 이 클래스를 상속받는 모든 테스트는 Rest Docs 기능을 사용하게 됩니다.
+ */
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsTest {
+
+    protected MockMvcRequestSpecification mockMvc;
+
+    private RestDocumentationContextProvider restDocumentation;
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.restDocumentation = restDocumentation;
+    }
+
+    /**
+     * RestAssuredMockMvc의 요청 스펙 반환
+     * 테스트 코드에서 given() 메서드를 통해 요청 빌더를 얻어 사용할 수 있음
+     *
+     * @return MockMvcRequestSpecification - MockMvc 기반 요청 스펙
+     */
+    protected MockMvcRequestSpecification given() {
+        return mockMvc;
+    }
+
+    /**
+     * 컨트롤러 객체를 받아 MockMvc와 RestAssuredMockMvc 요청 스펙을 초기화하고 반환함
+     * 테스트 대상 컨트롤러에 대해 문서화와 요청 테스트를 함께 수행할 수 있도록 설정
+     *
+     * @param controller 테스트 대상 컨트롤러 인스턴스
+     * @return MockMvcRequestSpecification - 해당 컨트롤러에 대한 요청 스펙
+     */
+    protected MockMvcRequestSpecification mockController(Object controller) {
+        MockMvc mockMvc = createMockMvc(controller);
+        return RestAssuredMockMvc.given().mockMvc(mockMvc);
+    }
+
+    /**
+     * 컨트롤러를 인자로 받아 MockMvc 객체를 생성함
+     * Jackson 메시지 컨버터를 설정하여 JSON 직렬화 설정을 커스터마이징함
+     * 또한 REST Docs 문서화 설정을 적용함
+     *
+     * @param controller 테스트 대상 컨트롤러
+     * @return MockMvc - 문서화 및 테스트에 사용할 MockMvc 객체
+     */
+    private MockMvc createMockMvc(Object controller) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(objectMapper());
+
+        return MockMvcBuilders.standaloneSetup(controller)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+                .setMessageConverters(converter)
+                .build();
+    }
+
+    /**
+     * Jackson ObjectMapper를 생성하여 날짜와 기간 관련 직렬화 방식을 타임스탬프 대신 ISO 포맷으로 설정함
+     * 모듈 자동 등록 기능도 활성화되어 있음
+     *
+     * @return ObjectMapper - 커스터마이징된 JSON ObjectMapper 인스턴스
+     */
+    private ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
+    }
+}

--- a/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsUtil.java
+++ b/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsUtil.java
@@ -1,0 +1,16 @@
+package com.capturecat.test.api;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+public class RestDocsUtil {
+
+    public static OperationRequestPreprocessor requestPreprocessor() {
+        return Preprocessors.preprocessRequest(Preprocessors.prettyPrint());
+    }
+
+    public static OperationResponsePreprocessor responsePreprocessor() {
+        return Preprocessors.preprocessResponse(Preprocessors.prettyPrint());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #7 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

Spring Rest Docs 설정을 했습니다. 조금 뻘짓을 하느라 생각보다 오래걸렸네요...

1. 루트 build.gradle을 생성했습니다.
2. 문서 관련 설정을 해서 core 모듈이 아닌 다른 모듈에서도 문서화가 가능하도록 했습니다.
3. html 문서는 jar 파일에 /docs/index.html로 들어갑니다. 그래서 /docs/** 이 경로에는 시큐리티 설정을 허용해줬습니다.

문서화하는 방법은 예시 테스트 코드처럼 작성한 뒤 .adoc 파일을 작성하시면 됩니다. adoc 파일은 도메인 별로나 분리할 수도 있으니 원하시면 분리해서 만드셔도 됩니다!

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

1. 인텔리제이에서 실행하면 문서가 안 뜨고, jar 파일을 실행시켜야 됩니다!! 확인해보시고 문서 형식 저희가 커스텀할 수 있으니 수정할 부분 알려주세요.
2. 저희 import 순서 컨벤션 정해야 할 듯 싶습니다!
3. 테스트 코드는 어떻게 짤 것인가
