### PR TITLE
fix: 분리된 adoc 파일에서 snippet 경로 참조 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,25 +23,34 @@ subprojects {
     apply plugin: 'org.asciidoctor.jvm.convert'
 
     configurations {
+        asciidoctorExt
         compileOnly {
             extendsFrom annotationProcessor
         }
+    }
+
+    ext {
+        snippetDir = file("build/generated-snippets")
     }
 
     dependencies {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    }
+
+    asciidoctor {
+        inputs.dir snippetDir
+        configurations 'asciidoctorExt'
+        dependsOn test
     }
 
     bootJar.enabled = false
     jar.enabled = true
 
     tasks.named('test') {
+        outputs.dir snippetDir
         useJUnitPlatform()
-    }
-
-    tasks.named('asciidoctor') {
-        dependsOn test
     }
 }

--- a/capturecat-core/src/docs/asciidoc/health.adoc
+++ b/capturecat-core/src/docs/asciidoc/health.adoc
@@ -1,0 +1,3 @@
+== Health API
+=== Health Check Get API
+operation::healthCheck[snippets='curl-request,http-response,response-fields']

--- a/capturecat-core/src/docs/asciidoc/index.adoc
+++ b/capturecat-core/src/docs/asciidoc/index.adoc
@@ -5,16 +5,8 @@
 :toc: left
 :toclevels: 3
 :sectlinks:
-:snippets: build/generated-snippets
+:adocPath: src/docs/asciidoc
 
-== Introduce
-캡쳐캣 Core API 문서입니다.
+include::{adocPath}/introduce.adoc[]
 
-== Health API
-=== Health Check Get API
-==== Curl Request
-include::{snippets}/healthCheck/curl-request.adoc[]
-==== Http Response
-include::{snippets}/healthCheck/http-response.adoc[]
-==== Response Fields
-include::{snippets}/healthCheck/response-fields.adoc[]
+include::{adocPath}/health.adoc[]

--- a/capturecat-core/src/docs/asciidoc/introduce.adoc
+++ b/capturecat-core/src/docs/asciidoc/introduce.adoc
@@ -1,0 +1,2 @@
+== Introduce
+캡쳐캣 Core API 문서입니다.

--- a/capturecat-tests/api-docs/src/main/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/capturecat-tests/api-docs/src/main/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|Path|Type|Nullable|Description
+
+{{#fields}}
+|{{path}}
+|{{type}}
+|{{optional}}
+|{{description}}
+{{/fields}}
+|===

--- a/capturecat-tests/api-docs/src/main/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/capturecat-tests/api-docs/src/main/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|Path|Type|Nullable|Description
+
+{{#fields}}
+|{{path}}
+|{{type}}
+|{{optional}}
+|{{description}}
+{{/fields}}
+|===


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #17 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

adoc 파일을 분리하면서 발생한 snippet 경로 참조 오류를 해결하고, 커스텀 요청/응답 필드 구조를 만들었습니다. nullable이 필요할 것 같아서요. 구조는 다음과 같아요.

| Path | Type | Nullable | Description
|-----|----|----|------

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
