### PR TITLE
feat: 태그 삭제 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -8,3 +8,11 @@
 [[단일-이미지-태그-등록]]
 ==== 단일 이미지 태그 등록
 include::{snippets}/errorCode/addTagsToImage/error-codes.adoc[]
+
+
+
+
+
+[[이미지-태그-삭제]]
+==== 이미지 태그 삭제
+include::{snippets}/errorCode/removeTagsToImage/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -1,12 +1,17 @@
-:snippets: ../../../build/generated-snippets
-
-== API 에러 코드
+= API 에러 코드
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:snippets: build/generated-snippets
 
 [[API-별-에러]]
-=== API 별 에러
+== API 별 에러
 
 [[단일-이미지-태그-등록]]
-==== 단일 이미지 태그 등록
+=== 단일 이미지 태그 등록
 include::{snippets}/errorCode/addTagsToImage/error-codes.adoc[]
 
 
@@ -14,5 +19,5 @@ include::{snippets}/errorCode/addTagsToImage/error-codes.adoc[]
 
 
 [[이미지-태그-삭제]]
-==== 이미지 태그 삭제
+=== 이미지 태그 삭제
 include::{snippets}/errorCode/removeTagsToImage/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/image.adoc
+++ b/capturecat-core/src/docs/asciidoc/image.adoc
@@ -9,6 +9,8 @@ operation::upload[snippets='curl-request,request-parts,http-response,response-fi
 ==== 실패
 이미지 업로드가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
+
+
 [[단일-이미지-태그-등록]]
 === 단일 이미지 태그 등록
 ==== 성공
@@ -18,3 +20,13 @@ operation::addTagsToImage[snippets='curl-request,request-fields,http-response,re
 단일 이미지에 태그 등록이 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#단일-이미지-태그-등록, 단일 이미지에 태그 등록 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+[[이미지-태그-삭제]]
+=== 이미지 태그 삭제
+==== 성공
+operation::removeTagsToImage[snippets='curl-request,request-fields,http-response,response-fields']
+
+==== 실패
+이미지 태그 삭제가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#이미지-태그-삭제, 이미지 태그 삭제 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/docs/asciidoc/index.adoc
+++ b/capturecat-core/src/docs/asciidoc/index.adoc
@@ -15,4 +15,5 @@ include::{adocPath}/image.adoc[]
 
 include::{adocPath}/health.adoc[]
 
-include::{adocPath}/error-codes.adoc[]
+== xref:error-codes.adoc[에러 코드]
+

--- a/capturecat-core/src/main/java/com/capturecat/core/api/image/ImageController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/image/ImageController.java
@@ -1,18 +1,26 @@
 package com.capturecat.core.api.image;
 
-import com.capturecat.core.api.image.dto.ImageMapper;
-import com.capturecat.core.api.image.dto.ImageRespDto.ImageListDto;
-import com.capturecat.core.domain.image.Image;
-import com.capturecat.core.service.image.ImageService;
-import com.capturecat.core.support.response.ApiResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.capturecat.core.api.image.dto.ImageRespDto.ImageListDto;
+import com.capturecat.core.api.image.dto.RemoveTagsToImageRequest;
+import com.capturecat.core.service.image.ImageService;
+import com.capturecat.core.support.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping(("/v1/images"))
@@ -35,4 +43,9 @@ public class ImageController {
         return ApiResponse.success();
     }
 
+    @DeleteMapping("/{imageId}/tags")
+    public ApiResponse<?> removeTagsFromImage(@PathVariable Long imageId, @RequestBody @Valid RemoveTagsToImageRequest request) {
+        imageService.removeTagsToImage(imageId, request.tagIds());
+        return ApiResponse.success();
+    }
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/RemoveTagsToImageRequest.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/RemoveTagsToImageRequest.java
@@ -1,0 +1,11 @@
+package com.capturecat.core.api.image.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record RemoveTagsToImageRequest(@NotEmpty(message = "잘못된 요청입니다.")
+                                       @NotNull(message = "잘못된 요청입니다.")
+                                       List<Long> tagIds) {
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -9,13 +9,9 @@ import com.capturecat.core.domain.image.Image;
 
 public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
-    long countByImage(Image image);
-
-    @Query("SELECT COUNT(it) FROM ImageTag it JOIN it.tag t WHERE it.image = :image AND t.name IN :tagNames")
-    long countByImageAndTagNameIn(Image image, List<String> tagNames);
-
     @Query("SELECT t.name FROM ImageTag it JOIN it.tag t WHERE it.image = :image")
     List<String> findTagNamesByImage(Image image);
 
-    boolean existsByImageAndTag(Image image, Tag tag);
+    @Query("SELECT it FROM ImageTag it JOIN it.tag t WHERE it.image = :image AND t.id IN :tagIds")
+    List<ImageTag> findByImageAndTagIds(Image image, List<Long> tagIds);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -1,26 +1,29 @@
 package com.capturecat.core.service.image;
 
-import com.capturecat.core.api.image.dto.ImageMapper;
-import com.capturecat.core.api.image.dto.ImageRespDto.ImageDto;
-import com.capturecat.core.api.image.dto.ImageRespDto.ImageListDto;
-import com.capturecat.core.domain.image.Image;
-import com.capturecat.core.domain.image.ImageRepository;
-import com.capturecat.core.domain.tag.*;
-import com.capturecat.core.support.error.CoreException;
-import com.capturecat.core.support.error.ErrorType;
-import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeToken;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.capturecat.core.api.image.dto.ImageMapper;
+import com.capturecat.core.api.image.dto.ImageRespDto.ImageListDto;
+import com.capturecat.core.domain.image.Image;
+import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.tag.ImageTag;
+import com.capturecat.core.domain.tag.ImageTagFactory;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagMaxCountValidator;
+import com.capturecat.core.domain.tag.TagRepository;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
 
 
 @Service
@@ -76,6 +79,17 @@ public class ImageService {
         tagRepository.saveAll(newTags);
         List<ImageTag> imageTags = imageTagFactory.create(image, newTags);
         imageTagRepository.saveAll(imageTags);
+    }
+
+    @Transactional
+    public void removeTagsToImage(Long imageId, List<Long> tagIds) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new CoreException(ErrorType.IMAGE_NOT_FOUND));
+        List<ImageTag> imageTags = imageTagRepository.findByImageAndTagIds(image, tagIds);
+        if (imageTags.isEmpty()) {
+            return;
+        }
+        imageTagRepository.deleteAll(imageTags);
     }
 
     private void validate(MultipartFile file) {

--- a/capturecat-core/src/main/java/com/capturecat/core/support/error/ErrorCode.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/support/error/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
 
     EXAMPLE_ERROR("An example error occurred."),
     NOT_FOUND_IMAGE("이미지를 찾을 수 없어요."),
-    EXCEED_MAX_TAG_COUNT("태그는 최대 4개까지만 추가할 수 있어요.");
+    EXCEED_MAX_TAG_COUNT("태그는 최대 4개까지만 추가할 수 있어요."),
+    INVALID_REQUEST("잘못된 요청입니다.");
 
     private final String message;
 

--- a/capturecat-core/src/main/java/com/capturecat/core/support/error/ErrorType.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/support/error/ErrorType.java
@@ -10,7 +10,8 @@ public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.EXAMPLE_ERROR, LogLevel.ERROR),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.NOT_FOUND_IMAGE, LogLevel.WARN),
-    TOO_MANY_TAGS(HttpStatus.BAD_REQUEST, ErrorCode.EXCEED_MAX_TAG_COUNT, LogLevel.WARN);
+    TOO_MANY_TAGS(HttpStatus.BAD_REQUEST, ErrorCode.EXCEED_MAX_TAG_COUNT, LogLevel.WARN),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_REQUEST, LogLevel.WARN);
 
     private final HttpStatus status;
 

--- a/capturecat-core/src/main/java/com/capturecat/core/support/handler/CoreExceptionHandler.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/support/handler/CoreExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.capturecat.core.support.handler;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -23,6 +24,13 @@ public class CoreExceptionHandler {
         }
         return ResponseEntity.status(e.getErrorType().getStatus())
                 .body(ApiResponse.error(e.getErrorType()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("Validation error occurred: {}", e.getMessage(), e);
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ErrorType.INVALID_REQUEST));
     }
 
     @ExceptionHandler(Exception.class)

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -15,6 +15,7 @@ import com.capturecat.test.snippet.ErrorCodeSnippet;
 import io.restassured.http.ContentType;
 
 import static com.capturecat.core.support.error.ErrorType.IMAGE_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.INVALID_REQUEST;
 import static com.capturecat.core.support.error.ErrorType.TOO_MANY_TAGS;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
@@ -39,5 +40,32 @@ class ErrorCodeControllerTest extends RestDocsTest {
                 .then()
                 .status(HttpStatus.OK)
                 .apply(document("errorCode/addTagsToImage", new ErrorCodeSnippet(errorCodeDescriptors)));
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    @Test
+    void 태그_삭제_에러_코드_문서() {
+        List<ErrorCodeDescriptor> errorCodeDescriptors = Stream.of(INVALID_REQUEST, IMAGE_NOT_FOUND)
+                .map(e -> new ErrorCodeDescriptor(e.getStatus().value(), e.getCode().name(), e.getCode().getMessage()))
+                .toList();
+
+        given().contentType(ContentType.JSON)
+                .when().get("/v1/error-codes")
+                .then()
+                .status(HttpStatus.OK)
+                .apply(document("errorCode/removeTagsToImage", new ErrorCodeSnippet(errorCodeDescriptors)));
     }
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageApiTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageApiTest.java
@@ -1,24 +1,33 @@
 package com.capturecat.core.api.image;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 
+import com.capturecat.core.api.image.dto.RemoveTagsToImageRequest;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.support.error.ErrorCode;
 import com.capturecat.core.support.error.ErrorMessage;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class ImageApiTest {
@@ -28,6 +37,9 @@ class ImageApiTest {
 
     @Autowired
     private ImageRepository imageRepository;
+
+    @Autowired
+    private ImageTagRepository imageTagRepository;
 
     private Long imageId;
 
@@ -113,5 +125,60 @@ class ImageApiTest {
         //then
         assertThat(error.code()).isEqualTo(ErrorCode.EXCEED_MAX_TAG_COUNT.name());
         assertThat(error.message()).isEqualTo(ErrorCode.EXCEED_MAX_TAG_COUNT.getMessage());
+    }
+
+    @Test
+    void 이미지_태그를_삭제한다() {
+        // given
+        AddTagsToImageRequest 단일_이미지_태그_등록_요청 = new AddTagsToImageRequest(List.of("tag1", "tag2"));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(단일_이미지_태그_등록_요청)
+                .when().post("/v1/images/{imageId}/tags", imageId)
+                .then();
+
+        RemoveTagsToImageRequest 태그_삭제_요청 = new RemoveTagsToImageRequest(List.of(1L, 2L));
+
+        // when
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(태그_삭제_요청)
+                .when().delete("/v1/images/{imageId}/tags", imageId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        // then
+        // TODO: 이미지 조회 및 태그 목록 조회 API 개발 후 재검증
+        Image image = imageRepository.findById(imageId).get();
+        List<String> tagNamesByImage = imageTagRepository.findTagNamesByImage(image);
+        assertThat(tagNamesByImage).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTagIdsRequests")
+    void 이미지_태그_삭제_시_잘못된_요청인_경우_400을_반환한다(RemoveTagsToImageRequest 태그_삭제_요청) {
+        // when
+        ExtractableResponse<Response> 태그_삭제_응답 = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(태그_삭제_요청)
+                .when().delete("/v1/images/{imageId}/tags", imageId)
+                .then().log().all()
+                .extract();
+
+        // then
+        ErrorMessage 오류_메시지 = 태그_삭제_응답.jsonPath().getObject("error", ErrorMessage.class);
+        assertSoftly(softly -> {
+            softly.assertThat(태그_삭제_응답.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            softly.assertThat(오류_메시지.code()).isEqualTo(ErrorCode.INVALID_REQUEST.name());
+            softly.assertThat(오류_메시지.message()).isEqualTo(ErrorCode.INVALID_REQUEST.getMessage());
+        });
+    }
+
+    private static Stream<RemoveTagsToImageRequest> invalidTagIdsRequests() {
+        return Stream.of(
+                new RemoveTagsToImageRequest(null),
+                new RemoveTagsToImageRequest(Collections.emptyList())
+        );
     }
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
@@ -1,15 +1,8 @@
 package com.capturecat.core.api.image;
 
-import com.capturecat.core.DummyObject;
-import com.capturecat.core.api.image.dto.ImageMapper;
-import com.capturecat.core.domain.image.Image;
-import com.capturecat.core.service.image.ImageService;
-import com.capturecat.core.support.error.CoreException;
-import com.capturecat.core.support.error.ErrorType;
-import com.capturecat.core.support.handler.CoreExceptionHandler;
-import com.capturecat.core.support.response.ApiResponse;
-import com.capturecat.test.api.RestDocsTest;
-import io.restassured.http.ContentType;
+import java.io.IOException;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
@@ -18,18 +11,32 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.util.List;
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.api.image.dto.ImageMapper;
+import com.capturecat.core.api.image.dto.RemoveTagsToImageRequest;
+import com.capturecat.core.domain.image.Image;
+import com.capturecat.core.service.image.ImageService;
+import com.capturecat.core.support.handler.CoreExceptionHandler;
+import com.capturecat.test.api.RestDocsTest;
+
+import io.restassured.http.ContentType;
 
 import static com.capturecat.test.api.RestDocsUtil.requestPreprocessor;
 import static com.capturecat.test.api.RestDocsUtil.responsePreprocessor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 
 @Transactional
 class ImageControllerTest extends RestDocsTest {
@@ -111,61 +118,29 @@ class ImageControllerTest extends RestDocsTest {
                                 fieldWithPath("error").type(JsonFieldType.OBJECT).ignored())));
     }
 
-
     @Test
-    void 단일_이미지에_태그를_등록_시_태그의_개수가_4개를_초과하면_안_된다() {
+    void 태그를_삭제한다() {
         // given
-        AddTagsToImageRequest request = new AddTagsToImageRequest(List.of("tag1", "tag2", "tag3", "tag4", "tag5"));
         Long imageId = 1L;
-        willThrow(new CoreException(ErrorType.TOO_MANY_TAGS)).given(imageService).addTagsToImage(anyLong(), any());
+        RemoveTagsToImageRequest request = new RemoveTagsToImageRequest(List.of(1L, 2L));
+        willDoNothing().given(imageService).removeTagsToImage(anyLong(), anyList());
 
         // when & then
         given().contentType(ContentType.JSON)
                 .body(request)
-                .when().post(URL_PREFIX + "/{imageId}/tags", imageId)
+                .when().delete(URL_PREFIX + "/{imageId}/tags", imageId)
                 .then()
-                .status(HttpStatus.BAD_REQUEST)
-                .apply(document("addTagsToImage/tooManyTags", requestPreprocessor(), responsePreprocessor(),
+                .status(HttpStatus.OK)
+                .apply(document("removeTagsToImage", requestPreprocessor(), responsePreprocessor(),
                         pathParameters(
-                                parameterWithName("imageId").description("태그를 등록할 이미지 ID")
+                                parameterWithName("imageId").description("태그를 삭제할 이미지 ID")
                         ),
                         requestFields(
-                                fieldWithPath("tagNames").type(JsonFieldType.ARRAY).description("등록할 태그 목록")
+                                fieldWithPath("tagIds").type(JsonFieldType.ARRAY).description("삭제할 태그 ID 목록")
                         ),
                         responseFields(
                                 fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).ignored(),
-                                fieldWithPath("error").type(JsonFieldType.OBJECT).description("에러 정보"),
-                                fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
-                                fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지"))));
-    }
-
-    @Test
-    void 단일_이미지에_태그를_등록_시_이미지가_존재하지_않으면_예외가_발생한다() {
-        // given
-        AddTagsToImageRequest request = new AddTagsToImageRequest(List.of("tag1", "tag2"));
-        Long imageId = 1L;
-        willThrow(new CoreException(ErrorType.IMAGE_NOT_FOUND)).given(imageService).addTagsToImage(anyLong(), any());
-
-
-        // when & then
-        given().contentType(ContentType.JSON)
-                .body(request)
-                .when().post(URL_PREFIX + "/{imageId}/tags", imageId)
-                .then()
-                .status(HttpStatus.NOT_FOUND)
-                .apply(document("addTagsToImage/imageNotFound", requestPreprocessor(), responsePreprocessor(),
-                        pathParameters(
-                                parameterWithName("imageId").description("태그를 등록할 이미지 ID")
-                        ),
-                        requestFields(
-                                fieldWithPath("tagNames").type(JsonFieldType.ARRAY).description("등록할 태그 목록")
-                        ),
-                        responseFields(
-                                fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).ignored(),
-                                fieldWithPath("error").type(JsonFieldType.OBJECT).description("에러 정보"),
-                                fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
-                                fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지"))));
+                                fieldWithPath("error").type(JsonFieldType.OBJECT).ignored())));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #10 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

ImageTag 중간 엔티티를 삭제함으로써 특정 이미지에서 태그를 제거하는 기능을 구현했습니다.
이 로직에서는 태그가 여전히 다른 이미지에서 사용 중인지 여부는 확인하지 않으며, 단순히 연결(ImageTag)만 삭제합니다.

태그가 더 이상 어떤 이미지에도 사용되지 않는 경우, 해당 태그 자체(Tag)를 정리하는 추가 로직을 고민했으나, 삭제 요청 로직이 과도한 책임을 가지게 되는 점을 고려해 포함하지 않았습니다.

향후 배치 작업 또는 스케줄러를 통해 사용되지 않는 태그를 주기적으로 정리하는 방식이 필요해 보입니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
