### PR TITLE
refactor: 단일 이미지 태그 등록 플로우 개선

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -17,4 +17,6 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
 	@Query("SELECT COUNT(it) > 0 FROM ImageTag it JOIN it.tag t WHERE it.image = :image AND t.name IN :tagNames")
 	boolean existsByImageAndTagNames(Image image, List<String> tagNames);
+
+	long countByImage(Image image);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagMaxCountValidator.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagMaxCountValidator.java
@@ -1,27 +1,38 @@
 package com.capturecat.core.domain.tag;
 
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
+import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 
 @Component
+@RequiredArgsConstructor
 public class TagMaxCountValidator {
 
 	private static final int TAG_MAX_COUNT = 4;
 
-	public void validate(Set<String> existingTagNames, List<String> newTagNames) {
-		long uniqueNewTagsCount = newTagNames.stream()
-			.filter(tag -> !existingTagNames.contains(tag))
-			.distinct()
-			.count();
+	private final ImageTagRepository imageTagRepository;
 
-		if (existingTagNames.size() + uniqueNewTagsCount > TAG_MAX_COUNT) {
+	public void validateTagCount(Image image, List<String> tagNames) {
+		validateNewTagListSize(tagNames);
+		validateTotalTagCount(image, tagNames);
+	}
+
+	private void validateNewTagListSize(List<String> tagNames) {
+		if (tagNames.size() > TAG_MAX_COUNT) {
 			throw new CoreException(ErrorType.TOO_MANY_TAGS);
 		}
 	}
 
+	private void validateTotalTagCount(Image image, List<String> tagNames) {
+		long existingTagCount = imageTagRepository.countByImage(image);
+		if (existingTagCount + tagNames.size() > TAG_MAX_COUNT) {
+			throw new CoreException(ErrorType.TOO_MANY_TAGS);
+		}
+	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagValidator.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagValidator.java
@@ -1,6 +1,8 @@
 package com.capturecat.core.domain.tag;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
@@ -12,18 +14,37 @@ import com.capturecat.core.support.error.ErrorType;
 
 @Component
 @RequiredArgsConstructor
-public class TagMaxCountValidator {
+public class TagValidator {
 
 	private static final int TAG_MAX_COUNT = 4;
 
 	private final ImageTagRepository imageTagRepository;
 
+	public void validateTagNames(Image image, List<String> tagNames) {
+		validateDuplicateTagNames(tagNames);
+		validateExistingTagsOnImage(image, tagNames);
+		validateTagCount(image, tagNames);
+	}
+
+	private void validateDuplicateTagNames(List<String> tagNames) {
+		Set<String> uniqueTagNames = new HashSet<>(tagNames);
+		if (uniqueTagNames.size() < tagNames.size()) {
+			throw new CoreException(ErrorType.DUPLICATE_TAG_NAMES);
+		}
+	}
+
+	private void validateExistingTagsOnImage(Image image, List<String> tagNames) {
+		if (imageTagRepository.existsByImageAndTagNames(image, tagNames)) {
+			throw new CoreException(ErrorType.ALREADY_REGISTERED_TAGS);
+		}
+	}
+
 	public void validateTagCount(Image image, List<String> tagNames) {
-		validateNewTagListSize(tagNames);
+		validateNewTagNamesSize(tagNames);
 		validateTotalTagCount(image, tagNames);
 	}
 
-	private void validateNewTagListSize(List<String> tagNames) {
+	private void validateNewTagNamesSize(List<String> tagNames) {
 		if (tagNames.size() > TAG_MAX_COUNT) {
 			throw new CoreException(ErrorType.TOO_MANY_TAGS);
 		}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -18,7 +18,6 @@ import com.capturecat.core.domain.tag.ImageTagFactory;
 import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.tag.Tag;
 import com.capturecat.core.domain.tag.TagRegister;
-import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.tag.TagValidator;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
@@ -30,11 +29,9 @@ public class ImageService {
 	private final FileUploader fileUploader;
 	private final ImageRepository imageRepository;
 	private final ImageTagRepository imageTagRepository;
-	private final TagRepository tagRepository;
 	private final ImageTagFactory imageTagFactory;
 	private final TagValidator tagValidator;
 	private final TagRegister tagRegister;
-	private final ImageMapper mapper;
 
 	@Transactional
 	public void save(List<UploadItemRequest> uploadItems, List<MultipartFile> files) {

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -1,9 +1,7 @@
 package com.capturecat.core.service.image;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +17,9 @@ import com.capturecat.core.domain.tag.ImageTag;
 import com.capturecat.core.domain.tag.ImageTagFactory;
 import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.tag.Tag;
-import com.capturecat.core.domain.tag.TagMaxCountValidator;
 import com.capturecat.core.domain.tag.TagRegister;
 import com.capturecat.core.domain.tag.TagRepository;
+import com.capturecat.core.domain.tag.TagValidator;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 
@@ -34,7 +32,7 @@ public class ImageService {
 	private final ImageTagRepository imageTagRepository;
 	private final TagRepository tagRepository;
 	private final ImageTagFactory imageTagFactory;
-	private final TagMaxCountValidator tagMaxCountValidator;
+	private final TagValidator tagValidator;
 	private final TagRegister tagRegister;
 	private final ImageMapper mapper;
 
@@ -63,8 +61,7 @@ public class ImageService {
 				.findFirst()
 				.orElseThrow(() -> new CoreException(ErrorType.TAG_INFO_MISMATCH));
 
-			validateDuplicateTagNames(tagNames);
-			tagMaxCountValidator.validateTagCount(savedImage, tagNames);
+			tagValidator.validateTagNames(savedImage, tagNames);
 
 			List<Tag> result = tagRegister.registerTagsFor(tagNames);
 			allImageTags.addAll(imageTagFactory.create(savedImage, result));
@@ -74,15 +71,10 @@ public class ImageService {
 
 	@Transactional
 	public void addTagsToImage(Long imageId, List<String> tagNames) {
-		validateDuplicateTagNames(tagNames);
 		Image image = imageRepository.findById(imageId)
 			.orElseThrow(() -> new CoreException(ErrorType.IMAGE_NOT_FOUND));
 
-		if (imageTagRepository.existsByImageAndTagNames(image, tagNames)) {
-			throw new CoreException(ErrorType.ALREADY_REGISTERED_TAGS);
-		}
-
-		tagMaxCountValidator.validateTagCount(image, tagNames);
+		tagValidator.validateTagNames(image, tagNames);
 
 		List<Tag> newTags = tagRegister.registerTagsFor(tagNames);
 		List<ImageTag> imageTags = imageTagFactory.create(image, newTags);
@@ -103,13 +95,6 @@ public class ImageService {
 		String contentType = file.getContentType();
 		if (contentType == null || !contentType.startsWith("image/")) {
 			throw new CoreException(ErrorType.INVALID_IMAGE_FORMAT);
-		}
-	}
-
-	private void validateDuplicateTagNames(List<String> tagNames) {
-		Set<String> uniqueTagNames = new HashSet<>(tagNames);
-		if (uniqueTagNames.size() < tagNames.size()) {
-			throw new CoreException(ErrorType.DUPLICATE_TAG_NAMES);
 		}
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -1,7 +1,6 @@
 package com.capturecat.core.service.image;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,7 +64,7 @@ public class ImageService {
 				.orElseThrow(() -> new CoreException(ErrorType.TAG_INFO_MISMATCH));
 
 			validateDuplicateTagNames(tagNames);
-			tagMaxCountValidator.validate(Collections.emptySet(), tagNames);
+			tagMaxCountValidator.validateTagCount(savedImage, tagNames);
 
 			List<Tag> result = tagRegister.registerTagsFor(tagNames);
 			allImageTags.addAll(imageTagFactory.create(savedImage, result));
@@ -74,26 +73,18 @@ public class ImageService {
 	}
 
 	@Transactional
-	// TODO: 플로우 개선
 	public void addTagsToImage(Long imageId, List<String> tagNames) {
 		validateDuplicateTagNames(tagNames);
 		Image image = imageRepository.findById(imageId)
 			.orElseThrow(() -> new CoreException(ErrorType.IMAGE_NOT_FOUND));
 
-		Set<String> existingTagNames = new HashSet<>(imageTagRepository.findTagNamesByImage(image));
-
 		if (imageTagRepository.existsByImageAndTagNames(image, tagNames)) {
 			throw new CoreException(ErrorType.ALREADY_REGISTERED_TAGS);
 		}
 
-		tagMaxCountValidator.validate(existingTagNames, tagNames);
+		tagMaxCountValidator.validateTagCount(image, tagNames);
 
-		List<Tag> newTags = tagNames.stream()
-			.filter(tagName -> !existingTagNames.contains(tagName))
-			.map(Tag::new)
-			.toList();
-
-		tagRepository.saveAll(newTags);
+		List<Tag> newTags = tagRegister.registerTagsFor(tagNames);
 		List<ImageTag> imageTags = imageTagFactory.create(image, newTags);
 		imageTagRepository.saveAll(imageTags);
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
@@ -10,8 +10,12 @@ import com.capturecat.core.domain.image.Image;
 
 public class DummyObject {
 
-	public static Image newMockImage(int id) {
-		return Image.builder().id((long) id).fileName("test1.jpg").fileUrl("testUrl1").build();
+	public static Image newMockImage(Long id) {
+		return Image.builder()
+			.id(id)
+			.fileName("test1.jpg")
+			.fileUrl("testUrl1")
+			.build();
 	}
 
 	public static List<Image> newMockImages(int fromId, int toId) {

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagMaxCountValidatorTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagMaxCountValidatorTest.java
@@ -1,78 +1,104 @@
 package com.capturecat.core.domain.tag;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 
+@ExtendWith(MockitoExtension.class)
 class TagMaxCountValidatorTest {
 
-	private TagMaxCountValidator validator = new TagMaxCountValidator();
+	@Mock
+	private ImageTagRepository imageTagRepository;
 
-	@Test
-	void 태그_총개수가_최대값과_같으면_정상적으로_통과된다() {
-		// given
-		Set<String> existingTags = Set.of("tag1", "tag2");
-		List<String> newTags = List.of("tag3", "tag4");
+	@InjectMocks
+	private TagMaxCountValidator tagMaxCountValidator;
 
-		// when & then
-		assertThatCode(() -> validator.validate(existingTags, newTags)).doesNotThrowAnyException();
+	private Image image;
+
+	@BeforeEach
+	void setUp() {
+		image = DummyObject.newMockImage(1L);
 	}
 
 	@Test
-	void 신규_태그가_없으면_정상적으로_통과된다() {
+	void 새로운_태그_목록_크기가_허용치_이하면_예외를_발생시키지_않아야_한다() {
 		// given
-		Set<String> existingTags = Set.of("tag1", "tag2");
-		List<String> newTags = List.of();
+		List<String> validTags = List.of("tag1", "tag2", "tag3", "tag4");
 
 		// when & then
-		assertThatCode(() -> validator.validate(existingTags, newTags)).doesNotThrowAnyException();
+		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, validTags))
+			.doesNotThrowAnyException();
 	}
 
 	@Test
-	void 기존_태그가_없고_신규_태그만으로_최대값일_경우_통과된다() {
+	void 새로운_태그_목록_크기가_허용치를_초과하면_TOO_MANY_TAGS_예외를_발생시켜야_한다() {
 		// given
-		Set<String> existingTags = Set.of();
-		List<String> newTags = List.of("tag1", "tag2", "tag3", "tag4");
+		List<String> tooManyTags = List.of("tag1", "tag2", "tag3", "tag4", "tag5");
 
 		// when & then
-		assertThatCode(() -> validator.validate(existingTags, newTags)).doesNotThrowAnyException();
-	}
-
-	@Test
-	void 신규_태그에_중복이_있어도_한번만_카운트된다() {
-		// given
-		Set<String> existingTags = Set.of("tag1");
-		List<String> newTags = List.of("tag2", "tag2", "tag3");
-
-		// when & then
-		assertThatCode(() -> validator.validate(existingTags, newTags)).doesNotThrowAnyException();
-	}
-
-	@Test
-	void 신규_태그가_기존_태그에_포함되어_있으면_카운트되지_않는다() {
-		// given
-		Set<String> existingTags = Set.of("tag1", "tag2");
-		List<String> newTags = List.of("tag2", "tag3");
-
-		// when & then
-		assertThatCode(() -> validator.validate(existingTags, newTags)).doesNotThrowAnyException();
-	}
-
-	@Test
-	void 태그_총개수가_최대값을_초과하면_예외가_발생한다() {
-		// given
-		Set<String> existingTags = Set.of("tag1", "tag2", "tag3");
-		List<String> newTags = List.of("tag4", "tag5");
-
-		// when & then
-		assertThatThrownBy(() -> validator.validate(existingTags, newTags)).isInstanceOf(CoreException.class)
+		assertThatThrownBy(() -> tagMaxCountValidator.validateTagCount(image, tooManyTags))
+			.isInstanceOf(CoreException.class)
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.TOO_MANY_TAGS);
 	}
 
+	@Test
+	void 기존_태그와_새로운_태그의_총합이_허용치_이하면_예외를_발생시키지_않아야_한다() {
+		// given
+		List<String> newTags = List.of("newTag1", "newTag2");
+		given(imageTagRepository.countByImage(any())).willReturn(2L);
+
+		// when & then
+		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void 기존_태그와_새로운_태그의_총합이_허용치를_초과하면_TOO_MANY_TAGS_예외를_발생시켜야_한다() {
+		// given
+		List<String> newTags = List.of("newTag1", "newTag2");
+		given(imageTagRepository.countByImage(any())).willReturn(3L);
+
+		// when & then
+		assertThatThrownBy(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue("errorType", ErrorType.TOO_MANY_TAGS);
+	}
+
+	@Test
+	void 기존_태그가_없는_경우_새로운_태그_목록의_크기가_허용치_이하면_예외를_발생시키지_않아야_한다() {
+		// given
+		List<String> newTags = List.of("newTag1", "newTag2", "newTag3", "newTag4");
+		given(imageTagRepository.countByImage(any())).willReturn(0L);
+
+		// when & then
+		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void 새로운_태그_목록이_비어있고_기존_태그_개수가_허용치_이하면_예외를_발생시키지_않아야_한다() {
+		// given
+		List<String> emptyTags = Collections.emptyList();
+		given(imageTagRepository.countByImage(any())).willReturn(4L);
+
+		// when & then
+		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, emptyTags))
+			.doesNotThrowAnyException();
+	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagValidatorTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagValidatorTest.java
@@ -3,6 +3,7 @@ package com.capturecat.core.domain.tag;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Collections;
@@ -21,13 +22,14 @@ import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 
 @ExtendWith(MockitoExtension.class)
-class TagMaxCountValidatorTest {
+class TagValidatorTest {
 
+	private static final String ERROR_TYPE = "errorType";
 	@Mock
 	private ImageTagRepository imageTagRepository;
 
 	@InjectMocks
-	private TagMaxCountValidator tagMaxCountValidator;
+	private TagValidator tagValidator;
 
 	private Image image;
 
@@ -37,24 +39,68 @@ class TagMaxCountValidatorTest {
 	}
 
 	@Test
+	void 중복된_태그_이름이_없으면_예외를_발생시키지_않아야_한다() {
+		// Given
+		List<String> uniqueTagNames = List.of("tag1", "tag2", "tag3");
+
+		// When & Then
+		assertThatCode(() -> tagValidator.validateTagNames(image, uniqueTagNames))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void 중복된_태그_이름이_있으면_예외가_발생한다() {
+		// Given
+		List<String> duplicateTagNames = List.of("tag1", "tag2", "tag1");
+
+		// When & Then
+		assertThatThrownBy(() -> tagValidator.validateTagNames(image, duplicateTagNames))
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue(ERROR_TYPE, ErrorType.DUPLICATE_TAG_NAMES);
+	}
+
+	@Test
+	void 이미지가_새로운_태그들을_가지고_있지_않으면_예외를_발생시키지_않아야_한다() {
+		// Given
+		List<String> newTags = List.of("newTag1", "newTag2");
+		given(imageTagRepository.existsByImageAndTagNames(any(), anyList())).willReturn(false);
+
+		// When & Then
+		assertThatCode(() -> tagValidator.validateTagNames(image, newTags))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void 이미지가_새로운_태그들_중_하나라도_가지고_있으면_예외가_발생한다() {
+		// Given
+		List<String> tagsWithExisting = List.of("existingTag", "newTag");
+		given(imageTagRepository.existsByImageAndTagNames(any(), anyList())).willReturn(true);
+
+		// When & Then
+		assertThatThrownBy(() -> tagValidator.validateTagNames(image, tagsWithExisting))
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue(ERROR_TYPE, ErrorType.ALREADY_REGISTERED_TAGS);
+	}
+
+	@Test
 	void 새로운_태그_목록_크기가_허용치_이하면_예외를_발생시키지_않아야_한다() {
 		// given
 		List<String> validTags = List.of("tag1", "tag2", "tag3", "tag4");
 
 		// when & then
-		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, validTags))
+		assertThatCode(() -> tagValidator.validateTagCount(image, validTags))
 			.doesNotThrowAnyException();
 	}
 
 	@Test
-	void 새로운_태그_목록_크기가_허용치를_초과하면_TOO_MANY_TAGS_예외를_발생시켜야_한다() {
+	void 새로운_태그_목록_크기가_허용치를_초과하면_예외가_발생한다_예외가_발생한다() {
 		// given
 		List<String> tooManyTags = List.of("tag1", "tag2", "tag3", "tag4", "tag5");
 
 		// when & then
-		assertThatThrownBy(() -> tagMaxCountValidator.validateTagCount(image, tooManyTags))
+		assertThatThrownBy(() -> tagValidator.validateTagCount(image, tooManyTags))
 			.isInstanceOf(CoreException.class)
-			.hasFieldOrPropertyWithValue("errorType", ErrorType.TOO_MANY_TAGS);
+			.hasFieldOrPropertyWithValue(ERROR_TYPE, ErrorType.TOO_MANY_TAGS);
 	}
 
 	@Test
@@ -64,20 +110,20 @@ class TagMaxCountValidatorTest {
 		given(imageTagRepository.countByImage(any())).willReturn(2L);
 
 		// when & then
-		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+		assertThatCode(() -> tagValidator.validateTagCount(image, newTags))
 			.doesNotThrowAnyException();
 	}
 
 	@Test
-	void 기존_태그와_새로운_태그의_총합이_허용치를_초과하면_TOO_MANY_TAGS_예외를_발생시켜야_한다() {
+	void 기존_태그와_새로운_태그의_총합이_허용치를_초과하면_예외가_발생한다() {
 		// given
 		List<String> newTags = List.of("newTag1", "newTag2");
 		given(imageTagRepository.countByImage(any())).willReturn(3L);
 
 		// when & then
-		assertThatThrownBy(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+		assertThatThrownBy(() -> tagValidator.validateTagCount(image, newTags))
 			.isInstanceOf(CoreException.class)
-			.hasFieldOrPropertyWithValue("errorType", ErrorType.TOO_MANY_TAGS);
+			.hasFieldOrPropertyWithValue(ERROR_TYPE, ErrorType.TOO_MANY_TAGS);
 	}
 
 	@Test
@@ -87,7 +133,7 @@ class TagMaxCountValidatorTest {
 		given(imageTagRepository.countByImage(any())).willReturn(0L);
 
 		// when & then
-		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, newTags))
+		assertThatCode(() -> tagValidator.validateTagCount(image, newTags))
 			.doesNotThrowAnyException();
 	}
 
@@ -98,7 +144,7 @@ class TagMaxCountValidatorTest {
 		given(imageTagRepository.countByImage(any())).willReturn(4L);
 
 		// when & then
-		assertThatCode(() -> tagMaxCountValidator.validateTagCount(image, emptyTags))
+		assertThatCode(() -> tagValidator.validateTagCount(image, emptyTags))
 			.doesNotThrowAnyException();
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #42 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그 검증하면서 단일 이미지 태그 등록 플로우를 개선했습니다. 이 과정에서 태그 검증 관련 로직을 모두 `TagValidator`로 모았습니다.

### AS-IS

- 요청으로 들어온 태그가 이미지에 이미 등록된 태그여도 무시하고 태그 개수 검증

### TO-BE

- 요청으로 들어온 태그는 이미지에 등록된 태그와 다르다고 가정 -> 이미 등록된 태그인 경우 예외 발생
- `TagRegister` 적용 

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
