### PR TITLE
feat: 태그로 이미지 검색 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -29,3 +29,7 @@ include::{snippets}/errorCode/getImagesWithTagsByUser/error-codes.adoc[]
 [[태그-목록-조회]]
 === 태그 목록 조회
 include::{snippets}/errorCode/getTags/error-codes.adoc[]
+
+[[태그로-이미지-검색]]
+=== 태그로 이미지 검색
+include::{snippets}/errorCode/searchImagesByTags/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/image.adoc
+++ b/capturecat-core/src/docs/asciidoc/image.adoc
@@ -31,6 +31,16 @@ operation::getImagesWithTagsByUser[snippets='curl-request,query-parameters,http-
 
 <<error-codes#태그-포함-이미지-목록-조회, 태그 포함 이미지 목록 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
 
+[[태그로-이미지-검색]]
+=== 태그로 이미지 검색
+==== 성공
+operation::searchImagesByTag[snippets='curl-request,query-parameters,http-response,response-fields']
+
+==== 실패
+태그로 이미지 검색이 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#태그로-이미지-검색, 태그로-이미지-검색 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
 [[이미지-태그-삭제]]
 === 이미지 태그 삭제
 ==== 성공

--- a/capturecat-core/src/main/java/com/capturecat/core/api/image/ImageController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/image/ImageController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,6 +55,13 @@ public class ImageController {
 	public ApiResponse<CursorResponse<ImageWithTagsResponse>> getImagesByUser(
 			@PageableDefault(size = 20) Pageable pageable) {
 		return ApiResponse.success(imageService.getImagesWithTags(pageable));
+	}
+
+	@GetMapping("/search")
+	public ApiResponse<CursorResponse<ImageWithTagsResponse>> searchImagesByTags(@RequestParam List<String> tagNames,
+		@PageableDefault(size = 20) Pageable pageable) {
+		CursorResponse<ImageWithTagsResponse> responses = imageService.searchImagesByTagNames(tagNames, pageable);
+		return ApiResponse.success(responses);
 	}
 
 	@DeleteMapping("/{imageId}/tags")

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepository.java
@@ -1,5 +1,7 @@
 package com.capturecat.core.domain.image;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -9,4 +11,6 @@ import com.capturecat.core.domain.user.User;
 public interface ImageCustomRepository {
 
 	Slice<ImageInfo> searchByUser(User user, Pageable pageable);
+
+	Slice<ImageInfo> searchImagesByUserAndTagNames(User user, List<String> tagNames, Pageable pageable);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
@@ -9,8 +9,10 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -43,5 +45,38 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 				));
 
 		return SliceUtil.toSlice(responses, pageable);
+	}
+
+	@Override
+	public Slice<ImageInfo> searchImagesByUserAndTagNames(User user, List<String> tagNames, Pageable pageable) {
+		List<ImageInfo> responses = queryFactory
+			.selectFrom(image)
+			.where(image.user.eq(user), buildHasAllTagsCondition(tagNames))
+			.leftJoin(imageTag).on(image.id.eq(imageTag.image.id))
+			.leftJoin(tag).on(imageTag.tag.id.eq(tag.id))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.orderBy(image.id.desc())
+			.transform(GroupBy.groupBy(image.id).list(Projections.constructor(ImageInfo.class,
+					image.id,
+					image.fileName,
+					image.fileUrl,
+					GroupBy.list(tag))
+			));
+
+		return SliceUtil.toSlice(responses, pageable);
+	}
+
+	private BooleanBuilder buildHasAllTagsCondition(List<String> tagNames) {
+		BooleanBuilder allTagsExistBuilder = new BooleanBuilder();
+		for (String tagName : tagNames) {
+			allTagsExistBuilder.and(JPAExpressions.selectOne()
+					.from(imageTag)
+					.join(imageTag.tag, tag)
+					.where(imageTag.image.id.eq(image.id), tag.name.eq(tagName))
+					.exists()
+			);
+		}
+		return allTagsExistBuilder;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -113,6 +113,19 @@ public class ImageService {
 		imageTagRepository.deleteAll(imageTags);
 	}
 
+	@Transactional(readOnly = true)
+	public CursorResponse<ImageWithTagsResponse> searchImagesByTagNames(List<String> tagNames, Pageable pageable) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		LoginUser loginUser = (LoginUser)authentication.getPrincipal();
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+
+		Slice<ImageWithTagsResponse> responses = imageRepository.searchImagesByUserAndTagNames(user, tagNames, pageable)
+			.map(ImageWithTagsResponse::of);
+
+		return CursorUtil.toCursorResponse(responses, ImageWithTagsResponse::id);
+	}
+
 	private void validate(MultipartFile file) {
 		String contentType = file.getContentType();
 		if (contentType == null || !contentType.startsWith("image/")) {

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -65,6 +65,12 @@ class ErrorCodeControllerTest extends RestDocsTest {
 		generateErrorDocs("errorCode/reissue", errorCodeDescriptors);
 	}
 
+	@Test
+	void 태그로_이미지_검색_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/searchImagesByTags", errorCodeDescriptors);
+	}
+
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {
 		given().contentType(ContentType.JSON)
 			.when().get("/v1/error-codes")
@@ -72,7 +78,7 @@ class ErrorCodeControllerTest extends RestDocsTest {
 			.apply(document(identifier, new ErrorCodeSnippet(errorCodeDescriptors)));
 	}
 
-	private static List<ErrorCodeDescriptor> generateErrorCodeDescriptors(ErrorType... errorTypes) {
+	private List<ErrorCodeDescriptor> generateErrorCodeDescriptors(ErrorType... errorTypes) {
 		return Stream.of(errorTypes)
 			.map(e -> new ErrorCodeDescriptor(e.getStatus().value(), e.getCode().name(), e.getCode().getMessage()))
 			.toList();

--- a/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
@@ -116,7 +116,7 @@ class ImageControllerTest extends RestDocsTest {
 	void 태그와_이미지를_조회한다() {
 		// given
 		BDDMockito.given(imageService.getImagesWithTags(any(Pageable.class)))
-			.willReturn(new CursorResponse(false, 1L,
+			.willReturn(new CursorResponse<>(false, 1L,
 				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg",
 					List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat"))))));
 
@@ -131,6 +131,42 @@ class ImageControllerTest extends RestDocsTest {
 					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
 					parameterWithName("size").description("페이지 크기 (기본값: 20, 최대: 100)").optional()
 				),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
+					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+					fieldWithPath("data.lastCursor").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
+					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("이미지 및 태그 목록"),
+					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("이미지 ID"),
+					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("이미지 이름"),
+					fieldWithPath("data.items[].url").type(JsonFieldType.STRING).description("이미지 URL"),
+					fieldWithPath("data.items[].tags").type(JsonFieldType.ARRAY).description("이미지에 등록된 태그 목록"),
+					fieldWithPath("data.items[].tags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+					fieldWithPath("data.items[].tags[].name").type(JsonFieldType.STRING).description("태그 이름"),
+					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
+	}
+
+	@Test
+	void 태그로_이미지를_검색한다() {
+		// given
+		List<String> tagNames = List.of("tag1", "tag2");
+
+		BDDMockito.given(imageService.searchImagesByTagNames(any(), any(Pageable.class)))
+			.willReturn(new CursorResponse<>(false, 1L,
+				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg",
+					List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat"))))));
+
+		// when & then
+		given().contentType(ContentType.JSON)
+			.param("tagNames", tagNames)
+			.param("page", 0)
+			.param("size", 20)
+			.when().get(URL_PREFIX + "/search")
+			.then().status(HttpStatus.OK)
+			.apply(document("searchImagesByTag", requestPreprocessor(), responsePreprocessor(),
+				queryParameters(
+					parameterWithName("tagNames").description("검색하는 태그 리스트").optional(),
+					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+					parameterWithName("size").description("페이지 크기 (기본값: 20, 최대: 100)").optional()),
 				responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
 					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
@@ -165,5 +201,4 @@ class ImageControllerTest extends RestDocsTest {
 					fieldWithPath("data").type(JsonFieldType.NULL).ignored(),
 					fieldWithPath("error").type(JsonFieldType.OBJECT).ignored())));
 	}
-
 }

--- a/capturecat-core/src/test/resources/application.yml
+++ b/capturecat-core/src/test/resources/application.yml
@@ -1,13 +1,13 @@
-spring:
-  profiles:
-    active: test
-
 server:
   port: 80
   servlet:
     encoding:
       charset: utf-8
       force: true
+
+spring:
+  profiles:
+    active: test
 
   datasource:
     url: jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #9 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그로 이미지 검색(필터링)을 하는 API를 구현했습니다. 태그는 여러 개의 태그를 입력받아, and 조건으로 검색을 진행합니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to search images by tags with pagination support.
  * Updated API documentation to include details and error codes for searching images by tags.

* **Bug Fixes**
  * Minor correction to a generic type in an existing test.

* **Tests**
  * Added tests for the new image search by tags endpoint.
  * Added tests and documentation for related error codes.

* **Documentation**
  * Expanded documentation to cover new image search functionality and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->