### PR TITLE
feat: 연관된 태그 조회 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/common-response.adoc
+++ b/capturecat-core/src/docs/asciidoc/common-response.adoc
@@ -5,7 +5,7 @@
 
 API 요청 URL은 배포 환경에 따라 서브 도메인이 변경될 수 있습니다.
 
-- 개발 환경: `https://dev.api.capture-cat.com`
+- 개발 환경: `https://dev.capture-cat.com`
 - 운영 환경: `https://api.capture-cat.com`
 
 문서는 개발 환경을 기준으로 작성되었지만, 운영 환경에서도 동일한 형식으로 요청할 수 있어요.

--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -30,6 +30,10 @@ include::{snippets}/errorCode/getImagesWithTagsByUser/error-codes.adoc[]
 === 태그 목록 조회
 include::{snippets}/errorCode/getTags/error-codes.adoc[]
 
+[[연관된-태그-조회]]
+=== 연관된 태그 조회
+include::{snippets}/errorCode/getRelatedTags/error-codes.adoc[]
+
 [[태그로-이미지-검색]]
 === 태그로 이미지 검색
 include::{snippets}/errorCode/searchImagesByTags/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/tag.adoc
+++ b/capturecat-core/src/docs/asciidoc/tag.adoc
@@ -1,8 +1,8 @@
 [[태그-API]]
 == 태그 API
 
-[[태그-목록-조회-API]]
-=== 태그 목록 조회 API
+[[태그-목록-조회]]
+=== 태그 목록 조회
 ==== 성공
 operation::getTags[snippets='curl-request,http-request,query-parameters,http-response,response-fields']
 
@@ -10,3 +10,13 @@ operation::getTags[snippets='curl-request,http-request,query-parameters,http-res
 태그 목록 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#태그-목록-조회, 태그 목록 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+[[연관된-태그-조회]]
+=== 연관된 태그 조회
+==== 성공
+operation::getRelatedTags[snippets='curl-request,http-request,query-parameters,http-response,response-fields']
+
+==== 실패
+연관된 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#연관된-태그-조회, 연관된 태그 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
@@ -26,7 +26,8 @@ public class TagController {
 	private final TagService tagService;
 
 	@GetMapping
-	public ApiResponse<?> getTags(@AuthenticationPrincipal LoginUser loginUser, @PageableDefault Pageable pageable) {
+	public ApiResponse<CursorResponse<TagResponse>> getTags(@AuthenticationPrincipal LoginUser loginUser,
+		@PageableDefault Pageable pageable) {
 		CursorResponse<TagResponse> tags = tagService.getTags(loginUser, pageable);
 		return ApiResponse.success(tags);
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
@@ -1,10 +1,13 @@
 package com.capturecat.core.api.tag;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,14 @@ public class TagController {
 	@GetMapping
 	public ApiResponse<?> getTags(@AuthenticationPrincipal LoginUser loginUser, @PageableDefault Pageable pageable) {
 		CursorResponse<TagResponse> tags = tagService.getTags(loginUser, pageable);
+		return ApiResponse.success(tags);
+	}
+
+	@GetMapping("/related")
+	public ApiResponse<CursorResponse<TagResponse>> getTagsByName(@AuthenticationPrincipal LoginUser loginUser,
+			@RequestParam List<String> tagNames,
+			@PageableDefault Pageable pageable) {
+		CursorResponse<TagResponse> tags = tagService.getRelatedTags(loginUser, tagNames, pageable);
 		return ApiResponse.success(tags);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.domain.image.dto.ImageInfo;
 import com.capturecat.core.domain.user.User;
+import com.capturecat.core.support.querydsl.CommonTagQueryConditions;
 import com.capturecat.core.support.util.SliceUtil;
 
 @RequiredArgsConstructor
@@ -52,7 +53,7 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 	public Slice<ImageInfo> searchImagesByUserAndTagNames(User user, List<String> tagNames, Pageable pageable) {
 		List<ImageInfo> responses = queryFactory
 			.selectFrom(image)
-			.where(image.user.eq(user), buildHasAllTagsCondition(tagNames))
+			.where(image.user.eq(user), CommonTagQueryConditions.createExistsCondition(tagNames))
 			.leftJoin(imageTag).on(image.id.eq(imageTag.image.id))
 			.leftJoin(tag).on(imageTag.tag.id.eq(tag.id))
 			.offset(pageable.getOffset())
@@ -67,18 +68,5 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 			));
 
 		return SliceUtil.toSlice(responses, pageable);
-	}
-
-	private BooleanBuilder buildHasAllTagsCondition(List<String> tagNames) {
-		BooleanBuilder allTagsExistBuilder = new BooleanBuilder();
-		for (String tagName : tagNames) {
-			allTagsExistBuilder.and(JPAExpressions.selectOne()
-					.from(imageTag)
-					.join(imageTag.tag, tag)
-					.where(imageTag.image.id.eq(image.id), tag.name.eq(tagName))
-					.exists()
-			);
-		}
-		return allTagsExistBuilder;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
@@ -1,5 +1,7 @@
 package com.capturecat.core.domain.tag;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -8,4 +10,6 @@ import com.capturecat.core.domain.user.User;
 public interface TagCustomRepository {
 
 	Slice<Tag> searchUserTagsByUser(User user, Pageable pageable);
+
+	Slice<Tag> searchByRelatedTags(User user, List<String> tagNames, Pageable pageable);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -9,13 +9,12 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.domain.user.User;
+import com.capturecat.core.support.querydsl.CommonTagQueryConditions;
 import com.capturecat.core.support.util.SliceUtil;
 
 @RequiredArgsConstructor
@@ -40,25 +39,16 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 
 	@Override
 	public Slice<Tag> searchByRelatedTags(User user, List<String> tagNames, Pageable pageable) {
-		BooleanBuilder allTagsExistBuilder = new BooleanBuilder();
-		for (String tagName : tagNames) {
-			allTagsExistBuilder.and(JPAExpressions.selectOne()
-				.from(imageTag)
-				.join(imageTag.tag, tag)
-				.where(imageTag.image.id.eq(image.id), tag.name.eq(tagName))
-				.exists()
-			);
-		}
-
 		List<Tag> tags = queryFactory
 			.select(tag).distinct()
 			.from(imageTag)
 			.join(imageTag.tag, tag)
-			.where(allTagsExistBuilder, tag.name.notIn(tagNames))
+			.where(CommonTagQueryConditions.createExistsCondition(tagNames), tag.name.notIn(tagNames))
 			.groupBy(tag)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
+
 		return SliceUtil.toSlice(tags, pageable);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -40,10 +40,14 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 	@Override
 	public Slice<Tag> searchByRelatedTags(User user, List<String> tagNames, Pageable pageable) {
 		List<Tag> tags = queryFactory
-			.select(tag).distinct()
+			.select(tag)
 			.from(imageTag)
 			.join(imageTag.tag, tag)
-			.where(CommonTagQueryConditions.createExistsCondition(tagNames), tag.name.notIn(tagNames))
+			.where(
+				image.user.eq(user),
+				CommonTagQueryConditions.createExistsCondition(tagNames),
+				tag.name.notIn(tagNames)
+			)
 			.groupBy(tag)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -9,6 +9,8 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,30 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
+		return SliceUtil.toSlice(tags, pageable);
+	}
+
+	@Override
+	public Slice<Tag> searchByRelatedTags(User user, List<String> tagNames, Pageable pageable) {
+		BooleanBuilder allTagsExistBuilder = new BooleanBuilder();
+		for (String tagName : tagNames) {
+			allTagsExistBuilder.and(JPAExpressions.selectOne()
+				.from(imageTag)
+				.join(imageTag.tag, tag)
+				.where(imageTag.image.id.eq(image.id), tag.name.eq(tagName))
+				.exists()
+			);
+		}
+
+		List<Tag> tags = queryFactory
+			.select(tag).distinct()
+			.from(imageTag)
+			.join(imageTag.tag, tag)
+			.where(allTagsExistBuilder, tag.name.notIn(tagNames))
+			.groupBy(tag)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
 		return SliceUtil.toSlice(tags, pageable);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -1,5 +1,7 @@
 package com.capturecat.core.service.tag;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,17 @@ public class TagService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		Slice<Tag> tags = tagRepository.searchUserTagsByUser(user, pageable);
+		Slice<TagResponse> responses = tags.map(TagResponse::from);
+
+		return CursorUtil.toCursorResponse(responses, TagResponse::id);
+	}
+
+	@Transactional(readOnly = true)
+	public CursorResponse<TagResponse> getRelatedTags(LoginUser loginUser, List<String> tagNames, Pageable pageable) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+
+		Slice<Tag> tags = tagRepository.searchByRelatedTags(user, tagNames, pageable);
 		Slice<TagResponse> responses = tags.map(TagResponse::from);
 
 		return CursorUtil.toCursorResponse(responses, TagResponse::id);

--- a/capturecat-core/src/main/java/com/capturecat/core/support/querydsl/CommonTagQueryConditions.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/support/querydsl/CommonTagQueryConditions.java
@@ -1,0 +1,29 @@
+package com.capturecat.core.support.querydsl;
+
+import static com.capturecat.core.domain.image.QImage.image;
+import static com.capturecat.core.domain.tag.QImageTag.imageTag;
+import static com.capturecat.core.domain.tag.QTag.tag;
+
+import java.util.List;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CommonTagQueryConditions {
+
+	public static BooleanBuilder createExistsCondition(List<String> tagNames) {
+		BooleanBuilder allTagsExistBuilder = new BooleanBuilder();
+		for (String tagName : tagNames) {
+			allTagsExistBuilder.and(JPAExpressions.selectOne()
+				.from(imageTag)
+				.join(imageTag.tag, tag)
+				.where(imageTag.image.id.eq(image.id), tag.name.eq(tagName))
+				.exists()
+			);
+		}
+		return allTagsExistBuilder;
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -123,7 +123,7 @@ class ErrorCodeControllerTest extends RestDocsTest {
 	@Test
 	void 연관된_태그_조회_에러_코드_문서() {
 		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
-		generateErrorDocs("errorCode/getRelatedBookmark", errorCodeDescriptors);
+		generateErrorDocs("errorCode/getRelatedTags", errorCodeDescriptors);
 	}
 
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -120,6 +120,12 @@ class ErrorCodeControllerTest extends RestDocsTest {
 		generateErrorDocs("errorCode/deleteBookmark", errorCodeDescriptors);
 	}
 
+	@Test
+	void 연관된_태그_조회_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/getRelatedBookmark", errorCodeDescriptors);
+	}
+
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {
 		given().contentType(ContentType.JSON)
 			.when().get("/v1/error-codes")

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
@@ -3,6 +3,7 @@ package com.capturecat.core.api.tag;
 import static com.capturecat.test.api.RestDocsUtil.requestPreprocessor;
 import static com.capturecat.test.api.RestDocsUtil.responsePreprocessor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -61,6 +62,37 @@ class TagControllerTest extends RestDocsTest {
 					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
 					fieldWithPath("data.lastCursor").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
 					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("태그 목록"),
+					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("태그 이름"),
+					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
+	}
+
+	@Test
+	void 연관된_태그_조회() {
+		// given
+		BDDMockito.given(tagService.getRelatedTags(any(), anyList(), any()))
+			.willReturn(new CursorResponse<>(false, 1L, List.of(
+				new TagResponse(1L, "relatedTag")
+			)));
+
+		// when & then
+		given().contentType(ContentType.JSON)
+			.param("page", 0)
+			.param("size", 10)
+			.param("tagNames", List.of("tag1", "tag2"))
+			.when().get("/v1/tags/related")
+			.then().status(HttpStatus.OK)
+			.apply(document("getTags", requestPreprocessor(), responsePreprocessor(),
+				queryParameters(
+					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+					parameterWithName("size").description("페이지 크기 (기본값: 10)").optional(),
+					parameterWithName("tagNames").description("검색에 사용되는 태그 이름 목록")
+				),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
+					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+					fieldWithPath("data.lastCursor").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
+					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("연관된 태그 목록"),
 					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("태그 이름"),
 					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
@@ -82,7 +82,7 @@ class TagControllerTest extends RestDocsTest {
 			.param("tagNames", List.of("tag1", "tag2"))
 			.when().get("/v1/tags/related")
 			.then().status(HttpStatus.OK)
-			.apply(document("getTags", requestPreprocessor(), responsePreprocessor(),
+			.apply(document("getRelatedTags", requestPreprocessor(), responsePreprocessor(),
 				queryParameters(
 					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
 					parameterWithName("size").description("페이지 크기 (기본값: 10)").optional(),

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.capturecat.core.domain.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.config.JpaAuditingConfig;
+import com.capturecat.core.config.QueryDslConfig;
+import com.capturecat.core.domain.image.Image;
+import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.user.UserRepository;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, JpaAuditingConfig.class})
+class TagRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@Autowired
+	private ImageTagRepository imageTagRepository;
+
+	@Autowired
+	private TagRepository tagRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void 연관_태그_조회() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("test"));
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag1 = tagRepository.save(new Tag("tag1"));
+		var tag2 = tagRepository.save(new Tag("tag2"));
+		var tag3 = tagRepository.save(new Tag("tag3"));
+		var tag4 = tagRepository.save(new Tag("tag4"));
+
+		saveImageTags(image1, List.of(tag1, tag2, tag3));
+		saveImageTags(image2, List.of(tag1, tag2, tag4));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		var tags = tagRepository.searchByRelatedTags(user, List.of("tag1", "tag2"), PageRequest.of(0, 10));
+
+		// then
+		assertThat(tags.getContent()).hasSize(2);
+		assertThat(tags.hasNext()).isFalse();
+		assertThat(tags.getContent()).extracting(Tag::getName)
+			.containsExactly(tag3.getName(), tag4.getName());
+	}
+
+	private void saveImageTags(Image image1, List<Tag> tags) {
+		for (Tag tag : tags) {
+			imageTagRepository.save(new ImageTag(image1, tag));
+		}
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/support/querydsl/CommonTagQueryConditionsTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/support/querydsl/CommonTagQueryConditionsTest.java
@@ -1,0 +1,41 @@
+package com.capturecat.core.support.querydsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.querydsl.core.types.Predicate;
+
+class CommonTagQueryConditionsTest {
+
+	@Test
+	void 태그_존재_여부_조건을_생성한다() {
+		// given
+		List<String> tagNames = Arrays.asList("tag1", "tag2");
+
+		// when
+		var result = CommonTagQueryConditions.createExistsCondition(tagNames);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getValue()).isNotNull().isInstanceOf(Predicate.class);
+	}
+
+	@Test
+	void 빈_태그_이름_리스트로_조건을_생성하면_빈_BooleanBuilder를_반환한다() {
+		// given
+		List<String> tagNames = Collections.emptyList();
+
+		// when
+		var result = CommonTagQueryConditions.createExistsCondition(tagNames);
+
+		// then
+		assertNotNull(result);
+		assertThat(result.getValue()).isNull();
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #72 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

검색할 때 검색창 하단에 조회되는 연관된 태그 조회 API를 구현했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve related tags based on provided tag names.
  * Introduced backend support for querying related tags and improved tag filtering logic.

* **Bug Fixes**
  * Updated the development API request URL in the documentation.

* **Tests**
  * Added comprehensive tests for related tag retrieval, tag query conditions, and error handling for the new endpoint.

* **Documentation**
  * Documented the new related tags API endpoint and its error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->