### PR TITLE
feat: 즐겨찾기 여부 추가

### DIFF
--- a/capturecat-core/src/docs/asciidoc/image.adoc
+++ b/capturecat-core/src/docs/asciidoc/image.adoc
@@ -14,7 +14,7 @@ operation::upload[snippets='curl-request,http-request,request-parts,request-part
 [[단일-이미지-태그-등록]]
 === 단일 이미지 태그 등록
 ==== 성공
-operation::addTagsToImage[snippets='curl-request,request-fields,http-response,response-fields']
+operation::addTagsToImage[snippets='curl-request,path-parameters,request-fields,http-response,response-fields']
 
 ==== 실패
 단일 이미지에 태그 등록이 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.

--- a/capturecat-core/src/docs/asciidoc/index.adoc
+++ b/capturecat-core/src/docs/asciidoc/index.adoc
@@ -17,7 +17,7 @@ include::{adocPath}/image.adoc[]
 
 include::{adocPath}/tag.adoc[]
 
-include:{adocPath}/bookmark.adoc[]
+include::{adocPath}/bookmark.adoc[]
 
 include::{adocPath}/health.adoc[]
 

--- a/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/UploadItemRequest.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/UploadItemRequest.java
@@ -4,5 +4,6 @@ import java.util.List;
 
 public record UploadItemRequest(String fileName,
 								String captureDate,
+								boolean isBookmarked,
 								List<String> tagNames) {
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.capturecat.core.domain.image;
 
+import static com.capturecat.core.domain.bookmark.QBookmark.bookmark;
 import static com.capturecat.core.domain.image.QImage.image;
 import static com.capturecat.core.domain.tag.QImageTag.imageTag;
 import static com.capturecat.core.domain.tag.QTag.tag;
@@ -9,10 +10,8 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -32,8 +31,9 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 		List<ImageInfo> responses = queryFactory
 			.selectFrom(image)
 			.where(image.user.eq(user))
-			.leftJoin(imageTag).on(image.id.eq(imageTag.image.id))
-			.leftJoin(tag).on(imageTag.tag.id.eq(tag.id))
+			.leftJoin(imageTag).on(image.eq(imageTag.image))
+			.leftJoin(tag).on(imageTag.tag.eq(tag))
+			.leftJoin(bookmark).on(image.eq(bookmark.image), bookmark.user.eq(user))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.orderBy(image.id.desc())
@@ -43,6 +43,7 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 					image.fileName,
 					image.fileUrl,
 					image.captureDate,
+					bookmark.id.isNotNull(),
 					GroupBy.list(tag))
 				));
 

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/dto/ImageInfo.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/dto/ImageInfo.java
@@ -9,5 +9,6 @@ public record ImageInfo(Long id,
 						String fileName,
 						String fileUrl,
 						LocalDate captureDate,
+						boolean isBookmarked,
 						List<Tag> tags) {
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -15,6 +15,7 @@ import com.capturecat.client.upload.DeleteException;
 import com.capturecat.client.upload.FileUploader;
 import com.capturecat.client.upload.UploadException;
 import com.capturecat.core.api.image.dto.UploadItemRequest;
+import com.capturecat.core.domain.bookmark.Bookmark;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
@@ -50,11 +51,13 @@ public class ImageService {
 
 	@Transactional
 	// TODO: UploadItemRequest의 api 패키지 의존성 제거 고민하기 및 트랜잭션 분리
+	// 역할이 너무 많음.. 이미지 업로드 -> 이미지 저장 -> 즐겨찾기 -> 태그 저장 -> 이미지 태그 저장
 	public void save(List<UploadItemRequest> uploadItems, List<MultipartFile> files, LoginUser loginUser) {
 		User user = userRepository.findByUsername(loginUser.getUsername())
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		List<Image> images = new ArrayList<>(files.size());
+		List<Bookmark> bookmarks = new ArrayList<>(files.size());
 		for (MultipartFile file : files) {
 			validate(file);
 			String fileUrl = upload(file);
@@ -69,9 +72,14 @@ public class ImageService {
 				.user(user)
 				.build();
 			images.add(image);
+
+			if (uploadItemRequest.isBookmarked()) {
+				bookmarks.add(new Bookmark(user, image));
+			}
 		}
 
 		List<Image> savedImages = imageRepository.saveAll(images);
+		bookmarkRepository.saveAll(bookmarks);
 
 		List<ImageTag> allImageTags = new ArrayList<>();
 		for (Image savedImage : savedImages) {

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -15,6 +15,7 @@ import com.capturecat.client.upload.DeleteException;
 import com.capturecat.client.upload.FileUploader;
 import com.capturecat.client.upload.UploadException;
 import com.capturecat.core.api.image.dto.UploadItemRequest;
+import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
 import com.capturecat.core.domain.tag.ImageTag;
@@ -45,6 +46,7 @@ public class ImageService {
 	private final TagRegister tagRegister;
 	private final TagRepository tagRepository;
 	private final UserRepository userRepository;
+	private final BookmarkRepository bookmarkRepository;
 
 	@Transactional
 	// TODO: UploadItemRequest의 api 패키지 의존성 제거 고민하기 및 트랜잭션 분리
@@ -105,7 +107,7 @@ public class ImageService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		Slice<ImageWithTagsResponse> responses = imageRepository.searchByUser(user, pageable)
-			.map(ImageWithTagsResponse::of);
+			.map(ImageWithTagsResponse::from);
 
 		return CursorUtil.toCursorResponse(responses, ImageWithTagsResponse::id);
 	}
@@ -134,7 +136,7 @@ public class ImageService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		Slice<ImageWithTagsResponse> responses = imageRepository.searchImagesByUserAndTagNames(user, tagNames, pageable)
-			.map(ImageWithTagsResponse::of);
+			.map(r -> ImageWithTagsResponse.from(r));
 
 		return CursorUtil.toCursorResponse(responses, ImageWithTagsResponse::id);
 	}
@@ -145,15 +147,14 @@ public class ImageService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 		Image image = imageRepository.findById(imageId)
 			.orElseThrow(() -> new CoreException(ErrorType.IMAGE_NOT_FOUND));
+		boolean isBookmarked = bookmarkRepository.existsByUserAndImage(user, image);
 
 		image.validateOwnership(user);
 
 		List<ImageTag> imageTags = imageTagRepository.findByImage(image);
 
 		return new ImageWithTagsResponse(image.getId(), image.getFileName(), image.getFileUrl(), image.getCaptureDate(),
-			imageTags.stream()
-				.map(it -> TagResponse.from(it.getTag()))
-				.toList());
+			isBookmarked, convertToTagResponses(imageTags));
 	}
 
 	@Transactional
@@ -180,6 +181,7 @@ public class ImageService {
 	private UploadItemRequest getMatchingUploadRequest(List<UploadItemRequest> uploadItems, String fileName) {
 		return uploadItems.stream()
 			.filter(i -> {
+				// TODO: 제거
 				System.out.println("i.fileName() = " + i.fileName());
 				System.out.println("fileName = " + fileName);
 				return i.fileName().equals(fileName);
@@ -202,5 +204,11 @@ public class ImageService {
 		} catch (DeleteException e) {
 			throw new CoreException(ErrorType.IMAGE_DELETE_FAILED);
 		}
+	}
+
+	private List<TagResponse> convertToTagResponses(List<ImageTag> imageTags) {
+		return imageTags.stream()
+			.map(it -> TagResponse.from(it.getTag()))
+			.toList();
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageWithTagsResponse.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageWithTagsResponse.java
@@ -9,15 +9,20 @@ import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.dto.ImageInfo;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ImageWithTagsResponse(Long id, String name, String url, LocalDate captureDate, List<TagResponse> tags) {
+public record ImageWithTagsResponse(Long id,
+									String name,
+									String url,
+									LocalDate captureDate,
+									boolean isBookmarked,
+									List<TagResponse> tags) {
 
-	public static ImageWithTagsResponse of(ImageInfo imageInfo) {
+	public static ImageWithTagsResponse from(ImageInfo imageInfo) {
 		return new ImageWithTagsResponse(imageInfo.id(), imageInfo.fileName(), imageInfo.fileUrl(),
-			imageInfo.captureDate(), TagResponse.from(imageInfo.tags()));
+			imageInfo.captureDate(), imageInfo.isBookmarked(), TagResponse.from(imageInfo.tags()));
 	}
 
 	public static ImageWithTagsResponse from(Image image) {
 		return new ImageWithTagsResponse(image.getId(), image.getFileName(), image.getFileUrl(),
-			image.getCaptureDate(), null);
+			image.getCaptureDate(), true, null);
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
@@ -45,6 +45,7 @@ public class DummyObject {
 		return Image.builder()
 			.fileName("test1.jpg")
 			.fileUrl("testUrl1")
+			.captureDate(LocalDate.now())
 			.user(user)
 			.build();
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
@@ -88,6 +88,7 @@ class BookmarkControllerTest extends RestDocsTest {
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("이미지 이름"),
 					fieldWithPath("data.items[].url").type(JsonFieldType.STRING).description("이미지 URL"),
 					fieldWithPath("data.items[].captureDate").type(JsonFieldType.STRING).description("캡처한 날짜"),
+					fieldWithPath("data.items[].isBookmarked").type(JsonFieldType.BOOLEAN).description("즐겨찾기 여부"),
 					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
 	}
 

--- a/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
@@ -65,8 +65,8 @@ class ImageControllerTest extends RestDocsTest {
 		willDoNothing().given(imageService).save(anyList(), anyList(), any());
 
 		List<UploadItemRequest> requests = List.of(
-			new UploadItemRequest("cat.jpg", LocalDate.now().toString(), List.of("고양이", "cat")),
-			new UploadItemRequest("dog.jpg", LocalDate.now().toString(), List.of("강아지", "dog"))
+			new UploadItemRequest("cat.jpg", LocalDate.now().toString(), true, List.of("고양이", "cat")),
+			new UploadItemRequest("dog.jpg", LocalDate.now().toString(), false, List.of("강아지", "dog"))
 		);
 
 		// when & then
@@ -84,6 +84,7 @@ class ImageControllerTest extends RestDocsTest {
 				requestPartFields("uploadItems",
 					fieldWithPath("[].fileName").description("이미지 파일 이름"),
 					fieldWithPath("[].captureDate").description("이미지를 캡처한 날짜"),
+					fieldWithPath("[].isBookmarked").description("이미지를 즐겨찾기 여부"),
 					fieldWithPath("[].tagNames").description("이미지에 등록할 태그 목록")
 				),
 				responseFields(

--- a/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/image/ImageControllerTest.java
@@ -116,7 +116,7 @@ class ImageControllerTest extends RestDocsTest {
 		// given
 		BDDMockito.given(imageService.getImagesWithTags(any(), any(Pageable.class)))
 			.willReturn(new CursorResponse<>(false, 1L,
-				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(),
+				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), true,
 					List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat"))))));
 
 		// when & then
@@ -139,6 +139,7 @@ class ImageControllerTest extends RestDocsTest {
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("이미지 이름"),
 					fieldWithPath("data.items[].url").type(JsonFieldType.STRING).description("이미지 URL"),
 					fieldWithPath("data.items[].captureDate").type(JsonFieldType.STRING).description("캡처한 날짜"),
+					fieldWithPath("data.items[].isBookmarked").type(JsonFieldType.BOOLEAN).description("즐겨찾기 여부"),
 					fieldWithPath("data.items[].tags").type(JsonFieldType.ARRAY).description("이미지에 등록된 태그 목록"),
 					fieldWithPath("data.items[].tags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.items[].tags[].name").type(JsonFieldType.STRING).description("태그 이름"),
@@ -152,7 +153,7 @@ class ImageControllerTest extends RestDocsTest {
 
 		BDDMockito.given(imageService.searchImagesByTagNames(any(), any(), any(Pageable.class)))
 			.willReturn(new CursorResponse<>(false, 1L,
-				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(),
+				List.of(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), false,
 					List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat"))))));
 
 		// when & then
@@ -176,6 +177,7 @@ class ImageControllerTest extends RestDocsTest {
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("이미지 이름"),
 					fieldWithPath("data.items[].url").type(JsonFieldType.STRING).description("이미지 URL"),
 					fieldWithPath("data.items[].captureDate").type(JsonFieldType.STRING).description("캡처한 날짜"),
+					fieldWithPath("data.items[].isBookmarked").type(JsonFieldType.BOOLEAN).description("즐겨찾기 여부"),
 					fieldWithPath("data.items[].tags").type(JsonFieldType.ARRAY).description("이미지에 등록된 태그 목록"),
 					fieldWithPath("data.items[].tags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.items[].tags[].name").type(JsonFieldType.STRING).description("태그 이름"),
@@ -188,7 +190,7 @@ class ImageControllerTest extends RestDocsTest {
 		Long imageId = 1L;
 
 		BDDMockito.given(imageService.getImageWithTags(anyLong(), any()))
-			.willReturn(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(),
+			.willReturn(new ImageWithTagsResponse(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), true,
 				List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat"))));
 
 		// when & then
@@ -203,6 +205,7 @@ class ImageControllerTest extends RestDocsTest {
 					fieldWithPath("data.name").type(JsonFieldType.STRING).description("이미지 이름"),
 					fieldWithPath("data.url").type(JsonFieldType.STRING).description("이미지 URL"),
 					fieldWithPath("data.captureDate").type(JsonFieldType.STRING).description("캡처한 날짜"),
+					fieldWithPath("data.isBookmarked").type(JsonFieldType.BOOLEAN).description("즐겨찾기 여부"),
 					fieldWithPath("data.tags").type(JsonFieldType.ARRAY).description("이미지에 등록된 태그 목록"),
 					fieldWithPath("data.tags[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.tags[].name").type(JsonFieldType.STRING).description("태그 이름"),

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.capturecat.core.domain.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.config.JpaAuditingConfig;
+import com.capturecat.core.config.QueryDslConfig;
+import com.capturecat.core.domain.bookmark.Bookmark;
+import com.capturecat.core.domain.bookmark.BookmarkRepository;
+import com.capturecat.core.domain.tag.ImageTag;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagRepository;
+import com.capturecat.core.domain.user.UserRepository;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class ImageRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@Autowired
+	private ImageTagRepository imageTagRepository;
+
+	@Autowired
+	private TagRepository tagRepository;
+
+	@Autowired
+	private BookmarkRepository bookmarkRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void searchByUser() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("testUser"));
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user));
+		Tag tag1 = tagRepository.save(new Tag("tag1"));
+		Tag tag2 = tagRepository.save(new Tag("tag2"));
+		imageTagRepository.save(new ImageTag(image1, tag1));
+		imageTagRepository.save(new ImageTag(image1, tag2));
+		imageTagRepository.save(new ImageTag(image2, tag1));
+		imageTagRepository.save(new ImageTag(image2, tag2));
+		bookmarkRepository.save(new Bookmark(user, image1));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		var response = imageRepository.searchByUser(user, PageRequest.of(0, 10));
+
+		// then
+		assertThat(response.getContent()).hasSize(2);
+		assertThat(response.getContent().get(0).isBookmarked()).isFalse();
+		assertThat(response.getContent().get(1).isBookmarked()).isTrue();
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #76 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

이미지 조회 및 업로드 요청에 즐겨찾기 여부 응답 필드를 추가했습니다. 다만, 조금 고민되는건 `이미지 업로드` 입니다. 현재 이미지 업로드에서 다음과 같은 로직이 수행됩니다.

- S3 이미지 업로드
- 이미지 DB에 저장
- 즐겨찾기 DB에 저장
- 태그가 존재하지 않는 경우 태그 DB에 저장
- 이미지 태그 DB에 저장

너무 많은 역할을 한다고 생각하는데.... 어떻게 분리할 방법이 없을까요? 이미지 성능 개선하면 아예 분리 되기는 하는데, 즐겨찾기를 분리해버리고 싶네요.. 좋은 방법있으면 알려주시면 감사하겠습니다🙇‍♂️

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking images as bookmarked during upload and displaying bookmark status in image details and lists.

* **Bug Fixes**
  * Corrected documentation include directive syntax for improved document processing.

* **Documentation**
  * Updated API documentation to include and describe the new bookmark status field in requests and responses.
  * Enhanced example requests to show path parameters and the new bookmark field.

* **Tests**
  * Expanded and added tests to cover bookmarking functionality and ensure accurate bookmark status handling in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->