### PR TITLE
feat: 가장 많이 사용된 태그 조회 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -34,6 +34,10 @@ include::{snippets}/errorCode/getTags/error-codes.adoc[]
 === 연관된 태그 조회
 include::{snippets}/errorCode/getRelatedTags/error-codes.adoc[]
 
+[[많이-사용된-태그-조회]]
+=== 많이 사용된 태그 조회
+include::{snippets}/errorCode/getMostUsedTags/error-codes.adoc[]
+
 [[태그로-이미지-검색]]
 === 태그로 이미지 검색
 include::{snippets}/errorCode/searchImagesByTags/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/tag.adoc
+++ b/capturecat-core/src/docs/asciidoc/tag.adoc
@@ -20,3 +20,15 @@ operation::getRelatedTags[snippets='curl-request,http-request,query-parameters,h
 연관된 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#연관된-태그-조회, 연관된 태그 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+[[많이-사용된-태그-조회]]
+=== 많이 사용된 태그 조회
+페이지 번호에 상관없이 페이지 크기만 사용해서 원하시는 개수만큼 조회하면 됩니다.
+
+==== 성공
+operation::getMostUsedTags[snippets='curl-request,http-request,query-parameters,http-response,response-fields']
+
+==== 실패
+많이 사용된 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#많이-사용된-태그-조회, 많이 사용된 태그 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
@@ -39,4 +39,10 @@ public class TagController {
 		CursorResponse<TagResponse> tags = tagService.getRelatedTags(loginUser, tagNames, pageable);
 		return ApiResponse.success(tags);
 	}
+
+	@GetMapping("/most-used")
+	public ApiResponse<CursorResponse<TagResponse>> getMostUsedTags(@AuthenticationPrincipal LoginUser loginUser,
+			@PageableDefault Pageable pageable) {
+		return ApiResponse.success(tagService.getMostUsedTags(loginUser, pageable));
+	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
@@ -23,11 +23,6 @@ public class Tag extends BaseTimeEntity {
 	private String name;
 
 	public Tag(String name) {
-		this(null, name);
-	}
-
-	public Tag(Long id, String name) {
-		this.id = id;
 		this.name = name;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
@@ -30,9 +30,4 @@ public class Tag extends BaseTimeEntity {
 		this.id = id;
 		this.name = name;
 	}
-
-	public boolean isSameNameAs(String name) {
-		return this.name.equals(name);
-	}
-
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
@@ -12,4 +12,6 @@ public interface TagCustomRepository {
 	Slice<Tag> searchUserTagsByUser(User user, Pageable pageable);
 
 	Slice<Tag> searchByRelatedTags(User user, List<String> tagNames, Pageable pageable);
+
+	Slice<Tag> searchMostUsedTagsByUser(User user, Pageable pageable);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -55,4 +55,21 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 
 		return SliceUtil.toSlice(tags, pageable);
 	}
+
+	@Override
+	public Slice<Tag> searchMostUsedTagsByUser(User user, Pageable pageable) {
+		List<Tag> tags = queryFactory
+			.select(tag)
+			.from(imageTag)
+			.join(imageTag.tag, tag)
+			.join(imageTag.image, image)
+			.where(image.user.eq(user))
+			.groupBy(tag)
+			.orderBy(imageTag.count().desc(), tag.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		return SliceUtil.toSlice(tags, pageable);
+	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -48,4 +48,15 @@ public class TagService {
 
 		return CursorUtil.toCursorResponse(responses, TagResponse::id);
 	}
+
+	@Transactional(readOnly = true)
+	public CursorResponse<TagResponse> getMostUsedTags(LoginUser loginUser, Pageable pageable) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+
+		Slice<Tag> tags = tagRepository.searchMostUsedTagsByUser(user, pageable);
+		Slice<TagResponse> responses = tags.map(TagResponse::from);
+
+		return CursorUtil.toCursorResponse(responses, TagResponse::id);
+	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -1,6 +1,7 @@
 package com.capturecat.core.service.tag;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,32 +30,25 @@ public class TagService {
 
 	@Transactional(readOnly = true)
 	public CursorResponse<TagResponse> getTags(LoginUser loginUser, Pageable pageable) {
-		User user = userRepository.findByUsername(loginUser.getUsername())
-			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-		Slice<Tag> tags = tagRepository.searchUserTagsByUser(user, pageable);
-		Slice<TagResponse> responses = tags.map(TagResponse::from);
-
-		return CursorUtil.toCursorResponse(responses, TagResponse::id);
+		return searchTagsWithCursor(loginUser, user -> tagRepository.searchUserTagsByUser(user, pageable));
 	}
 
 	@Transactional(readOnly = true)
 	public CursorResponse<TagResponse> getRelatedTags(LoginUser loginUser, List<String> tagNames, Pageable pageable) {
-		User user = userRepository.findByUsername(loginUser.getUsername())
-			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-		Slice<Tag> tags = tagRepository.searchByRelatedTags(user, tagNames, pageable);
-		Slice<TagResponse> responses = tags.map(TagResponse::from);
-
-		return CursorUtil.toCursorResponse(responses, TagResponse::id);
+		return searchTagsWithCursor(loginUser, user -> tagRepository.searchByRelatedTags(user, tagNames, pageable));
 	}
 
 	@Transactional(readOnly = true)
 	public CursorResponse<TagResponse> getMostUsedTags(LoginUser loginUser, Pageable pageable) {
+		return searchTagsWithCursor(loginUser, user -> tagRepository.searchMostUsedTagsByUser(user, pageable));
+	}
+
+	private CursorResponse<TagResponse> searchTagsWithCursor(LoginUser loginUser,
+		Function<User, Slice<Tag>> tagSearchFunction) {
 		User user = userRepository.findByUsername(loginUser.getUsername())
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
-		Slice<Tag> tags = tagRepository.searchMostUsedTagsByUser(user, pageable);
+		Slice<Tag> tags = tagSearchFunction.apply(user);
 		Slice<TagResponse> responses = tags.map(TagResponse::from);
 
 		return CursorUtil.toCursorResponse(responses, TagResponse::id);

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -1,7 +1,22 @@
 package com.capturecat.core.api.error;
 
-import static com.capturecat.core.support.error.ErrorType.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static com.capturecat.core.support.error.ErrorType.ALREADY_REGISTERED_TAGS;
+import static com.capturecat.core.support.error.ErrorType.BOOKMARK_DUPLICATION;
+import static com.capturecat.core.support.error.ErrorType.BOOKMARK_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.DUPLICATE_TAG_NAMES;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_ACCESS_DENIED;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_DELETE_FAILED;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_TAG_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_UPLOAD_FAILED;
+import static com.capturecat.core.support.error.ErrorType.INVALID_DATE_FORMAT;
+import static com.capturecat.core.support.error.ErrorType.INVALID_ID_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.INVALID_REFRESH_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.REFRESH_TOKEN_EXPIRED;
+import static com.capturecat.core.support.error.ErrorType.TOO_MANY_TAGS;
+import static com.capturecat.core.support.error.ErrorType.UPLOAD_METADATA_MISMATCH;
+import static com.capturecat.core.support.error.ErrorType.USER_NOT_FOUND;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -124,6 +139,12 @@ class ErrorCodeControllerTest extends RestDocsTest {
 	void 연관된_태그_조회_에러_코드_문서() {
 		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
 		generateErrorDocs("errorCode/getRelatedTags", errorCodeDescriptors);
+	}
+
+	@Test
+	void 가장_많이_사용된_태그_조회_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/getMostUsedTags", errorCodeDescriptors);
 	}
 
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
@@ -97,4 +97,33 @@ class TagControllerTest extends RestDocsTest {
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("태그 이름"),
 					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
 	}
+
+	@Test
+	void 가장_많이_사용된_태그_조회() {
+		// given
+		BDDMockito.given(tagService.getMostUsedTags(any(), any()))
+			.willReturn(new CursorResponse<>(false, 1L, List.of(
+				new TagResponse(1L, "relatedTag")
+			)));
+
+		// when & then
+		given().contentType(ContentType.JSON)
+			.param("page", 0)
+			.param("size", 10)
+			.when().get("/v1/tags/most-used")
+			.then().status(HttpStatus.OK)
+			.apply(document("getMostUsedTags", requestPreprocessor(), responsePreprocessor(),
+				queryParameters(
+					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+					parameterWithName("size").description("페이지 크기 (기본값: 10)").optional()
+				),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
+					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+					fieldWithPath("data.lastCursor").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
+					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("가장 많이 사용된 태그 목록"),
+					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
+					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("태그 이름"),
+					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
+	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
@@ -42,9 +42,7 @@ class TagControllerTest extends RestDocsTest {
 	void 사용자가_등록한_태그_목록을_조회한다() {
 		// given
 		BDDMockito.given(tagService.getTags(any(), any()))
-			.willReturn(new CursorResponse<>(false, 1L, List.of(
-				new TagResponse(1L, "tagName")
-			)));
+			.willReturn(new CursorResponse<>(false, 1L, List.of(new TagResponse(1L, "tagName"))));
 
 		// when & then
 		given().contentType(ContentType.JSON)
@@ -71,9 +69,7 @@ class TagControllerTest extends RestDocsTest {
 	void 연관된_태그_조회() {
 		// given
 		BDDMockito.given(tagService.getRelatedTags(any(), anyList(), any()))
-			.willReturn(new CursorResponse<>(false, 1L, List.of(
-				new TagResponse(1L, "relatedTag")
-			)));
+			.willReturn(new CursorResponse<>(false, 1L, List.of(new TagResponse(1L, "relatedTag"))));
 
 		// when & then
 		given().contentType(ContentType.JSON)
@@ -102,9 +98,7 @@ class TagControllerTest extends RestDocsTest {
 	void 가장_많이_사용된_태그_조회() {
 		// given
 		BDDMockito.given(tagService.getMostUsedTags(any(), any()))
-			.willReturn(new CursorResponse<>(false, 1L, List.of(
-				new TagResponse(1L, "relatedTag")
-			)));
+			.willReturn(new CursorResponse<>(false, 1L, List.of(new TagResponse(1L, "tag"))));
 
 		// when & then
 		given().contentType(ContentType.JSON)

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagFixture.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagFixture.java
@@ -1,0 +1,12 @@
+package com.capturecat.core.domain.tag;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TagFixture {
+
+	public static Tag createTag(Long id, String name) {
+		Tag tag = new Tag(name);
+		ReflectionTestUtils.setField(tag, "id", id);
+		return tag;
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import jakarta.persistence.EntityManager;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,6 +18,7 @@ import com.capturecat.core.config.JpaAuditingConfig;
 import com.capturecat.core.config.QueryDslConfig;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
 
 @DataJpaTest
@@ -38,12 +40,26 @@ class TagRepositoryTest {
 	@Autowired
 	private EntityManager entityManager;
 
+	private User user;
+
+	private Image image1;
+
+	private Image image2;
+
+	private Image image3;
+
+	@BeforeEach
+	void setUp() {
+		user = userRepository.save(DummyObject.newUser("test"));
+
+		image1 = imageRepository.save(DummyObject.newMockUserImage(user));
+		image2 = imageRepository.save(DummyObject.newMockUserImage(user));
+		image3 = imageRepository.save(DummyObject.newMockUserImage(user));
+	}
+
 	@Test
 	void 연관_태그_조회() {
 		// given
-		var user = userRepository.save(DummyObject.newUser("test"));
-		var image1 = imageRepository.save(DummyObject.newMockUserImage(user));
-		var image2 = imageRepository.save(DummyObject.newMockUserImage(user));
 		var tag1 = tagRepository.save(new Tag("tag1"));
 		var tag2 = tagRepository.save(new Tag("tag2"));
 		var tag3 = tagRepository.save(new Tag("tag3"));
@@ -63,6 +79,39 @@ class TagRepositoryTest {
 		assertThat(tags.hasNext()).isFalse();
 		assertThat(tags.getContent()).extracting(Tag::getName)
 			.containsExactly(tag3.getName(), tag4.getName());
+	}
+
+	@Test
+	void 사용자가_가장_많이_사용한_태그_순으로_조회한다() {
+		// given
+		var tag1 = tagRepository.save(new Tag("tag1"));
+		var tag2 = tagRepository.save(new Tag("tag2"));
+		var tag3 = tagRepository.save(new Tag("tag3"));
+
+		// tag1은 3개의 이미지에 사용
+		imageTagRepository.save(new ImageTag(image1, tag1));
+		imageTagRepository.save(new ImageTag(image2, tag1));
+		imageTagRepository.save(new ImageTag(image3, tag1));
+
+		// tag2는 2개의 이미지에 사용
+		imageTagRepository.save(new ImageTag(image1, tag2));
+		imageTagRepository.save(new ImageTag(image2, tag2));
+
+		// tag3는 1개의 이미지에 사용
+		imageTagRepository.save(new ImageTag(image1, tag3));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		var result = tagRepository.searchMostUsedTagsByUser(user, PageRequest.of(0, 10));
+
+		// then
+		List<Tag> tags = result.getContent();
+		assertThat(tags).hasSize(3);
+		assertThat(tags.get(0).getName()).isEqualTo(tag1.getName());
+		assertThat(tags.get(1).getName()).isEqualTo(tag2.getName());
+		assertThat(tags.get(2).getName()).isEqualTo(tag3.getName());
 	}
 
 	private void saveImageTags(Image image1, List<Tag> tags) {

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -73,6 +73,7 @@ class TagServiceTest {
 
 		// when & then
 		assertThatThrownBy(() -> tagService.getMostUsedTags(loginUser, of(0, 10)))
-			.isInstanceOf(CoreException.class);
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue("errorType", ErrorType.USER_NOT_FOUND);
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -21,7 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 
 import com.capturecat.core.DummyObject;
-import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagFixture;
 import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
@@ -45,7 +45,7 @@ class TagServiceTest {
 		// given
 		var user = DummyObject.newMockUser(1L);
 		var loginUser = new LoginUser(user);
-		var tags = List.of(new Tag(1L, "java"), new Tag(1L, "spring"));
+		var tags = List.of(TagFixture.createTag(1L, "java"), TagFixture.createTag(1L, "spring"));
 		var pageRequest = of(0, 10);
 		var tagSlice = new SliceImpl<>(tags, pageRequest, false);
 

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -1,0 +1,78 @@
+package com.capturecat.core.service.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.data.domain.PageRequest.of;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagRepository;
+import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+	@Mock
+	private TagRepository tagRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private TagService tagService;
+
+	@Test
+	void 가장_많이_사용된_태그를_조회한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var loginUser = new LoginUser(user);
+		var tags = List.of(new Tag(1L, "java"), new Tag(1L, "spring"));
+		var pageRequest = of(0, 10);
+		var tagSlice = new SliceImpl<>(tags, pageRequest, false);
+
+		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
+		given(tagRepository.searchMostUsedTagsByUser(eq(user), any(Pageable.class))).willReturn(tagSlice);
+
+		// when
+		var response = tagService.getMostUsedTags(loginUser, pageRequest);
+
+		// then
+		assertThat(response.items()).hasSize(2);
+		assertThat(response.items().get(0).name()).isEqualTo("java");
+		assertThat(response.items().get(1).name()).isEqualTo("spring");
+		assertThat(response.hasNext()).isFalse();
+
+		verify(tagRepository).searchMostUsedTagsByUser(eq(user), any(Pageable.class));
+	}
+
+	@Test
+	void 가장_많이_사용된_태그를_조회_시_회원이_존재하지_않으면_실패한다() {
+		// given
+		LoginUser loginUser = new LoginUser(DummyObject.newMockUser(1L));
+
+		given(userRepository.findByUsername(anyString())).willThrow(new CoreException(ErrorType.USER_NOT_FOUND));
+
+		// when & then
+		assertThatThrownBy(() -> tagService.getMostUsedTags(loginUser, of(0, 10)))
+			.isInstanceOf(CoreException.class);
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #79 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

유저가 가장 많이 사용한 태그 조회를 구현했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve the most frequently used tags for a user, supporting paginated results.
  * Expanded documentation to describe the new "Most Used Tags" feature and its error codes.

* **Documentation**
  * Updated user and error code documentation to include details and usage examples for the new "Most Used Tags" API.

* **Tests**
  * Added and enhanced tests to verify correct ordering, pagination, and error handling for the most used tags feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->