### PR TITLE
feat: 튜토리얼 완료 여부 업데이트 및 소셜로그인 응답 변경

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -59,9 +59,13 @@ include::{snippets}/errorCode/deleteBookmark/error-codes.adoc[]
 include::{snippets}/errorCode/socialLogin/error-codes.adoc[]
 
 [[엑세스-토큰-재발급]]
-=== 엑세스-토큰-재발급
+=== 엑세스 토큰 재발급
 include::{snippets}/errorCode/reissue/error-codes.adoc[]
 
 [[로그아웃]]
 === 로그아웃
 include::{snippets}/errorCode/logout/error-codes.adoc[]
+
+[[튜토리얼-완료-업데이트]]
+=== 튜토리얼 완료 업데이트
+include::{snippets}/errorCode/tutorialComplete/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/index.adoc
+++ b/capturecat-core/src/docs/asciidoc/index.adoc
@@ -13,6 +13,8 @@ include::{adocPath}/common-response.adoc[]
 
 include::{adocPath}/auth.adoc[]
 
+include::{adocPath}/user.adoc[]
+
 include::{adocPath}/image.adoc[]
 
 include::{adocPath}/tag.adoc[]

--- a/capturecat-core/src/docs/asciidoc/user.adoc
+++ b/capturecat-core/src/docs/asciidoc/user.adoc
@@ -1,0 +1,12 @@
+[[회원-API]]
+== 회원 관련 API
+
+[[튜토리얼-완료-업데이트]]
+=== 튜토리얼(시작하기) 완료 업데이트
+==== 성공
+operation::tutorialComplete[snippets='curl-request,http-request,http-response,response-fields']
+
+==== 실패
+튜토리얼(시작하기) 완료 업데이트가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#튜토리얼-완료-업데이트, 튜토리얼 완료 업데이트 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/auth/Oauth2AuthController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/auth/Oauth2AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.api.auth.dto.SocialLoginRequest;
+import com.capturecat.core.api.auth.dto.SocialLoginResponse;
 import com.capturecat.core.config.jwt.JwtUtil;
 import com.capturecat.core.config.jwt.TokenType;
 import com.capturecat.core.service.auth.IdTokenVerifierService;
@@ -49,6 +50,7 @@ public class Oauth2AuthController {
 		return ResponseEntity
 			.ok()
 			.headers(headers)
-			.body(ApiResponse.success());
+			.body(ApiResponse.success(
+				new SocialLoginResponse(user.getUsername(), user.getNickname(), user.isTutorialCompleted())));
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/auth/dto/SocialLoginResponse.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/auth/dto/SocialLoginResponse.java
@@ -1,0 +1,4 @@
+package com.capturecat.core.api.auth.dto;
+
+public record SocialLoginResponse(String email, String nickname, boolean tutorialCompleted) {
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -2,6 +2,7 @@ package com.capturecat.core.api.user;
 
 import jakarta.validation.Valid;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
 import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
+import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
 import com.capturecat.core.support.response.ApiResponse;
 
@@ -26,5 +28,11 @@ public class UserController {
 	public ApiResponse<JoinRespDto> join(@RequestBody @Valid JoinReqDto joinReqDto, BindingResult bindingResult) {
 		JoinRespDto joinRespDto = userService.join(joinReqDto);
 		return ApiResponse.success(joinRespDto);
+	}
+
+	@PostMapping("/tutorial")
+	public ApiResponse<?> tutorialCompleted(@AuthenticationPrincipal LoginUser loginUser) {
+		userService.updateTutorialCompleted(loginUser);
+		return ApiResponse.success();
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
 		return ApiResponse.success(joinRespDto);
 	}
 
-	@PostMapping("/tutorial")
+	@PostMapping("/tutorialComplete")
 	public ApiResponse<?> tutorialCompleted(@AuthenticationPrincipal LoginUser loginUser) {
 		userService.updateTutorialCompleted(loginUser);
 		return ApiResponse.success();

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
@@ -40,6 +40,7 @@ public class UserReqDto {
 				.password(passwordEncoder.encode(password))
 				.email(email)
 				.role(UserRole.USER)
+				.nickname(username)
 				.build();
 		}
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/User.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/User.java
@@ -28,13 +28,16 @@ public class User extends BaseTimeEntity {
 	private Long id;
 
 	@Column(unique = true, nullable = false, length = 50)
-	private String username; //nickname
+	private String username;
 
 	@Column(length = 70) //패스워드 인코딩(BCrypt)
 	private String password;
 
 	@Column(nullable = false, length = 50)
 	private String email;
+
+	@Column(nullable = false, length = 50)
+	private String nickname;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -43,13 +46,16 @@ public class User extends BaseTimeEntity {
 	private String provider;   // "google", "apple", "kakao" 등
 	private String socialId;   // 소셜 서비스의 "sub" (고유 OIDC ID)
 
+	private boolean tutorialCompleted = false;
+
 	@Builder
-	public User(Long id, String username, String password, String email, UserRole role,
-		String provider, String socialId) {
+	public User(Long id, String username, String password, String email, String nickname,
+		UserRole role, String provider, String socialId) {
 		this.id = id;
 		this.username = username;
 		this.password = password;
 		this.email = email;
+		this.nickname = nickname;
 		this.role = role;
 		this.provider = provider;
 		this.socialId = socialId;

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/User.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/User.java
@@ -60,4 +60,8 @@ public class User extends BaseTimeEntity {
 		this.provider = provider;
 		this.socialId = socialId;
 	}
+
+	public void tutorialComplete() {
+		this.tutorialCompleted = true;
+	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/auth/IdTokenVerifierService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/auth/IdTokenVerifierService.java
@@ -56,11 +56,12 @@ public class IdTokenVerifierService {
 			// 3. 공개키(JWK)로 서명 검증.
 			verifyJwtSignature(jwt, providerInfo);
 
-			// 4. 유저 정보 반환 (provider, sub, email, email_verified)
+			// 4. 유저 정보 반환 (provider, sub, email, nickname, email_verified)
 			return new OidcUserPayload(
 				provider,
 				claims.getSubject(),
 				claims.getStringClaim("email"),
+				extractNickname(provider, claims),
 				claims.getBooleanClaim("email_verified")
 			);
 		} catch (Exception e) {
@@ -104,10 +105,20 @@ public class IdTokenVerifierService {
 		return claims;
 	}
 
+	private String extractNickname(String provider, JWTClaimsSet claims) throws ParseException {
+		return switch (provider) {
+			case "kakao" -> claims.getStringClaim("nickname");
+			case "apple" -> claims.getStringClaim("fullName");
+			case "google" -> claims.getStringClaim("name");
+			default -> claims.getStringClaim("email");
+		};
+	}
+
 	public record OidcUserPayload(
 		String provider,
 		String sub, // OIDC에서 각 사용자를 "서비스 내에서 고유하게 구별"하는 고유 식별자(Primary Key)
 		String email,
+		String nickname,
 		Boolean emailVerified
 	) {
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/auth/LoginUser.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/auth/LoginUser.java
@@ -18,14 +18,19 @@ public class LoginUser implements UserDetails {
 
 	private String username;
 	private String password;
+	private String nickname;
 	private UserRole role;
+	private boolean tutorialCompleted;
 
 	public LoginUser(User user) {
 		this.username = user.getUsername();
 		this.password = user.getPassword();
-		this.role =  user.getRole();
+		this.nickname = user.getNickname();
+		this.role = user.getRole();
+		this.tutorialCompleted = user.isTutorialCompleted(); //TODO
 	}
 
+	//엑세스 토큰에서 사용자 정보 추출 시 사용
 	public LoginUser(String username, String role) {
 		this.username = username;
 		this.role = UserRole.fromRoleString(role);

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -2,6 +2,7 @@ package com.capturecat.core.service.user;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +18,7 @@ import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class UserService {
 
@@ -57,5 +59,11 @@ public class UserService {
 			.socialId(payload.sub())
 			.role(UserRole.USER)
 			.build();
+	}
+
+	public void updateTutorialCompleted(LoginUser loginUser) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		user.tutorialComplete();
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -51,6 +51,7 @@ public class UserService {
 	private User buildUser(OidcUserPayload payload) {
 		return User.builder()
 			.username(payload.email() != null ? payload.email() : payload.provider() + "_" + payload.sub())
+			.nickname(payload.nickname())
 			.email(payload.email())
 			.provider(payload.provider())
 			.socialId(payload.sub())

--- a/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
@@ -67,6 +67,7 @@ public class DummyObject {
 			.username("username")
 			.password(passwordEncoder.encode("password"))
 			.email("username@email.com")
+			.nickname("nickname")
 			.build();
 	}
 
@@ -78,6 +79,7 @@ public class DummyObject {
 			.username(username)
 			.password(encPassword)
 			.email(username + "@email.com")
+			.nickname(username)
 			.role(UserRole.USER)
 			.build();
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerSliceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerSliceTest.java
@@ -60,7 +60,7 @@ class Oauth2AuthControllerSliceTest {
 		String idToken = "test-id-token";
 		SocialLoginRequest req = new SocialLoginRequest(idToken);
 		OidcUserPayload payload =
-			new OidcUserPayload(provider, "1234", "test@test.com", true);
+			new OidcUserPayload(provider, "1234", "test@test.com", "testNickname", true);
 
 		LoginUser user = buildUser(payload);
 
@@ -87,7 +87,7 @@ class Oauth2AuthControllerSliceTest {
 			.andExpect(header().string(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + "access.jwt.token"))
 			.andExpect(header().string(JwtUtil.REFRESH_TOKEN_HEADER, JwtUtil.BEARER_PREFIX + "refresh.jwt.token"))
 			.andExpect(jsonPath("$.result").value("SUCCESS"))
-			.andExpect(jsonPath("$.data").doesNotExist());
+			.andExpect(jsonPath("$.data").exists());
 	}
 
 	@DisplayName("id_token 검증 실패 시 401 응답")

--- a/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerTest.java
@@ -53,7 +53,7 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 		String idToken = "test-id-token";
 		SocialLoginRequest request = new SocialLoginRequest(idToken);
 		OidcUserPayload payload =
-			new OidcUserPayload(provider, "1234", "test@test.com", true);
+			new OidcUserPayload(provider, "1234", "test@test.com", "testNickname", true);
 		LoginUser user = buildUser(payload);
 		Map<TokenType, String> tokenMap = Map.of(
 			TokenType.ACCESS, "access.jwt.token",
@@ -81,7 +81,10 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 					headerWithName(JwtUtil.REFRESH_TOKEN_HEADER).description("Bearer 리프레시 토큰")
 				),
 				responseFields(
-					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과 (예: SUCCESS)")
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과 (예: SUCCESS)"),
+					fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("닉네임"),
+					fieldWithPath("data.tutorialCompleted").type(JsonFieldType.BOOLEAN).description("튜토리얼(시작하기) 완료 여부")
 				)));
 	}
 
@@ -92,6 +95,7 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 			.socialId(payload.sub())
 			.role(UserRole.USER)
 			.username(payload.email() != null ? payload.email() : payload.provider() + "_" + payload.sub())
+			.nickname(payload.nickname())
 			.build();
 		return new LoginUser(user);
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -126,6 +126,12 @@ class ErrorCodeControllerTest extends RestDocsTest {
 		generateErrorDocs("errorCode/getRelatedTags", errorCodeDescriptors);
 	}
 
+	@Test
+	void 튜토리얼_완료_업데이트_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/tutorialComplete", errorCodeDescriptors);
+	}
+
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {
 		given().contentType(ContentType.JSON)
 			.when().get("/v1/error-codes")

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
@@ -1,0 +1,38 @@
+package com.capturecat.core.api.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.capturecat.core.service.user.UserService;
+import com.capturecat.test.api.RestDocsTest;
+
+class UserControllerTest extends RestDocsTest {
+
+	private static final String URL_PREFIX = "/v1/user";
+
+	private final ObjectMapper om = new ObjectMapper();
+
+	private UserController userController;
+
+	private UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		userService = mock(UserService.class);
+		userController = new UserController(userService);
+		mockMvc = mockController(userController);
+	}
+
+	@Test
+	void 튜토리얼_완료_업데이트() {
+		// given
+
+		// when & then
+	}
+
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
@@ -1,13 +1,23 @@
 package com.capturecat.core.api.user;
 
+import static com.capturecat.test.api.RestDocsUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.restassured.http.ContentType;
+
+import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
 import com.capturecat.test.api.RestDocsTest;
 
@@ -31,8 +41,15 @@ class UserControllerTest extends RestDocsTest {
 	@Test
 	void 튜토리얼_완료_업데이트() {
 		// given
+		willDoNothing().given(userService).updateTutorialCompleted(any(LoginUser.class));
 
 		// when & then
+		given().contentType(ContentType.JSON).log().all()
+			.when().post(URL_PREFIX + "/tutorialComplete")
+			.then().status(HttpStatus.OK)
+			.apply(document("tutorialComplete", requestPreprocessor(), responsePreprocessor(),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"))));
 	}
 
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/auth/IdTokenVerifierServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/auth/IdTokenVerifierServiceTest.java
@@ -38,12 +38,12 @@ class IdTokenVerifierServiceTest {
 		Provider provider = new Provider();
 		provider.setIssuerUri("https://test-issuer.com");
 		provider.setJwkSetUri("https://test-issuer.com/keys");
-		props.getProvider().put("test", provider);
+		props.getProvider().put("google", provider);
 
 		// 2. Registration 세팅
 		Registration reg = new Registration();
 		reg.setClientId("test-client-id");
-		props.getRegistration().put("test", reg);
+		props.getRegistration().put("google", reg);
 
 		// 3. 서비스 생성
 		service = Mockito.spy(new IdTokenVerifierService(props));
@@ -70,6 +70,7 @@ class IdTokenVerifierServiceTest {
 			.subject("mysub")
 			.claim("email", "test@test.com")
 			.claim("email_verified", true)
+			.claim("name", "testNickname")
 			.build();
 
 		SignedJWT idToken = TestJwtUtil.createJwt(claims, privateKey);
@@ -78,12 +79,13 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		//when
-		OidcUserPayload payload = service.verifyAndExtract("test", idToken.serialize());
+		OidcUserPayload payload = service.verifyAndExtract("google", idToken.serialize());
 
 		//then
-		assertThat(payload.provider()).isEqualTo("test");
+		assertThat(payload.provider()).isEqualTo("google");
 		assertThat(payload.sub()).isEqualTo("mysub");
 		assertThat(payload.email()).isEqualTo("test@test.com");
+		assertThat(payload.nickname()).isEqualTo("testNickname");
 		assertThat(payload.emailVerified()).isTrue();
 	}
 
@@ -105,7 +107,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("test", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize())
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);
@@ -129,7 +131,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("test", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize())
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);
@@ -153,7 +155,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("test", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize())
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);

--- a/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
@@ -5,6 +5,8 @@ import static com.capturecat.core.api.user.dto.UserReqDto.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +16,9 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -44,5 +48,23 @@ class UserServiceTest {
 
 		//then
 		Assertions.assertEquals(1L, joinRespDto.getId());
+	}
+
+	@Test
+	void 튜토리얼_완료_업데이트() {
+		//given
+		//기 회원 만들기
+		User savedUser = newMockUser(1L);
+
+		//기본값 false
+		Assertions.assertEquals(false, savedUser.isTutorialCompleted());
+
+		when(userRepository.findByUsername(savedUser.getUsername())).thenReturn(Optional.of(savedUser));
+
+		//when
+		userService.updateTutorialCompleted(new LoginUser(savedUser));
+
+		//then
+		Assertions.assertEquals(true, savedUser.isTutorialCompleted());
 	}
 }

--- a/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsUtil.java
+++ b/capturecat-tests/api-docs/src/main/java/com/capturecat/test/api/RestDocsUtil.java
@@ -11,7 +11,7 @@ public class RestDocsUtil {
 
 	public static OperationRequestPreprocessor requestPreprocessor() {
 		return Preprocessors.preprocessRequest(
-				Preprocessors.modifyUris().scheme("https").host("dev.capture-cat.com").removePort(),
+				Preprocessors.modifyUris().scheme("https").host("api.capture-cat.com").removePort(),
 				Preprocessors.prettyPrint());
 	}
 


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #80 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
 - 소셜 회원가입 시 닉네임 수신
 -  튜토리얼(시작하기) 완료 여부 업데이트 API
 - 로그인 결과값으로 시작하기 완료 여부 및 닉네임 응답
 - API 문서에 url이 dev.로 시작하는 것을 api.로 수정


## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- user 도메인에 필수값으로 nickname을 추가하는 바람에, merge 시 깨질 수 있으니 참고 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for user nicknames and tutorial completion status, now included in user profiles and social login responses.
  * Introduced a new API endpoint to mark tutorial completion for authenticated users.

* **Bug Fixes**
  * Ensured nickname is properly set during user registration and social login processes.

* **Documentation**
  * Expanded API documentation to cover tutorial completion features and related error codes.
  * Updated and reorganized error code and user-related documentation sections.

* **Tests**
  * Added and updated tests to verify nickname handling, tutorial completion logic, and new API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->