### PR TITLE
fix: 즐겨찾기 여부 추가로 인한 QueryDSL Projection 오류 및 연관된 태그 오류 해결

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCustomRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 					image.captureDate,
 					bookmark.id.isNotNull(),
 					GroupBy.list(tag))
-				));
+			));
 
 		return SliceUtil.toSlice(responses, pageable);
 	}
@@ -54,9 +54,10 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 	public Slice<ImageInfo> searchImagesByUserAndTagNames(User user, List<String> tagNames, Pageable pageable) {
 		List<ImageInfo> responses = queryFactory
 			.selectFrom(image)
-			.where(image.user.eq(user), CommonTagQueryConditions.createExistsCondition(tagNames))
+			.leftJoin(bookmark).on(image.eq(bookmark.image), bookmark.user.eq(user))
 			.leftJoin(imageTag).on(image.id.eq(imageTag.image.id))
 			.leftJoin(tag).on(imageTag.tag.id.eq(tag.id))
+			.where(image.user.eq(user), CommonTagQueryConditions.createExistsCondition(tagNames))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.orderBy(image.id.desc())
@@ -65,6 +66,7 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
 				image.fileName,
 				image.fileUrl,
 				image.captureDate,
+				bookmark.isNotNull(),
 				GroupBy.list(tag))
 			));
 

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -42,6 +42,7 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 		List<Tag> tags = queryFactory
 			.select(tag)
 			.from(imageTag)
+			.join(imageTag.image, image)
 			.join(imageTag.tag, tag)
 			.where(
 				image.user.eq(user),

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -144,7 +144,7 @@ public class ImageService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		Slice<ImageWithTagsResponse> responses = imageRepository.searchImagesByUserAndTagNames(user, tagNames, pageable)
-			.map(r -> ImageWithTagsResponse.from(r));
+			.map(ImageWithTagsResponse::from);
 
 		return CursorUtil.toCursorResponse(responses, ImageWithTagsResponse::id);
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageRepositoryTest.java
@@ -2,6 +2,8 @@ package com.capturecat.core.domain.image;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import jakarta.persistence.EntityManager;
 
 import org.junit.jupiter.api.Test;
@@ -67,5 +69,82 @@ class ImageRepositoryTest {
 		assertThat(response.getContent()).hasSize(2);
 		assertThat(response.getContent().get(0).isBookmarked()).isFalse();
 		assertThat(response.getContent().get(1).isBookmarked()).isTrue();
+	}
+
+	@Test
+	void searchImagesByUserAndTagNames() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("testUser"));
+		var anotherUser = userRepository.save(DummyObject.newUser("anotherUser"));
+
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var image3 = imageRepository.save(DummyObject.newMockUserImage(anotherUser));
+
+		var tag1 = tagRepository.save(new Tag("java"));
+		var tag2 = tagRepository.save(new Tag("spring"));
+		var tag3 = tagRepository.save(new Tag("kotlin"));
+
+		imageTagRepository.save(new ImageTag(image1, tag1));
+		imageTagRepository.save(new ImageTag(image1, tag2));
+		imageTagRepository.save(new ImageTag(image2, tag1));
+		imageTagRepository.save(new ImageTag(image2, tag3));
+		imageTagRepository.save(new ImageTag(image3, tag1));
+
+		bookmarkRepository.save(new Bookmark(user, image1));
+		bookmarkRepository.save(new Bookmark(user, image2));
+		bookmarkRepository.save(new Bookmark(anotherUser, image3));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		var pageRequest = PageRequest.of(0, 10);
+
+		// when
+		var response = imageRepository.searchImagesByUserAndTagNames(user, List.of("java", "spring"), pageRequest);
+
+		// then
+		assertThat(response.getContent()).hasSize(1);
+	}
+
+	@Test
+	void searchImagesByUserAndTagNames_noMatchingTags() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("testUser"));
+		var image = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag = tagRepository.save(new Tag("java"));
+
+		imageTagRepository.save(new ImageTag(image, tag));
+		bookmarkRepository.save(new Bookmark(user, image));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		var pageRequest = PageRequest.of(0, 10);
+
+		// when
+		var response = imageRepository.searchImagesByUserAndTagNames(user, List.of("python", "django"), pageRequest);
+
+		// then
+		assertThat(response.getContent()).isEmpty();
+	}
+
+	@Test
+	void searchImagesByUserAndTagNames_noBookmarks() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("testUser"));
+		var image = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag = tagRepository.save(new Tag("java"));
+
+		imageTagRepository.save(new ImageTag(image, tag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		var response = imageRepository.searchImagesByUserAndTagNames(user, List.of("java"), PageRequest.of(0, 10));
+
+		// then
+		assertThat(response.getContent()).hasSize(1);
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
@@ -64,9 +64,11 @@ class TagRepositoryTest {
 		var tag2 = tagRepository.save(new Tag("tag2"));
 		var tag3 = tagRepository.save(new Tag("tag3"));
 		var tag4 = tagRepository.save(new Tag("tag4"));
+		var tag5 = tagRepository.save(new Tag("tag5"));
 
 		saveImageTags(image1, List.of(tag1, tag2, tag3));
 		saveImageTags(image2, List.of(tag1, tag2, tag4));
+		saveImageTags(image3, List.of(tag5));
 
 		entityManager.flush();
 		entityManager.clear();


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #87 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 즐겨찾기 여부 추가로 인한 QueryDSL Projection 오류 해결
- 연관된 태그 조회에서 연관되지 않은 태그가 조회되는 버그 해결

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of image search results when filtering by user and tags, ensuring bookmark status is correctly reflected.
  * Enhanced related tag search to ensure images are properly associated with the current user.

* **Refactor**
  * Simplified internal code for mapping search results, with no change to user-facing behavior.

* **Tests**
  * Added and updated tests to verify image search by user and tags, including scenarios with and without bookmarks.
  * Expanded tag-related tests to cover additional tag and image associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->