### PR TITLE
fix: apple 로그인 시 nickname 별로 수신

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/api/auth/Oauth2AuthController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/auth/Oauth2AuthController.java
@@ -32,9 +32,10 @@ public class Oauth2AuthController {
 	private final TokenService tokenService;
 
 	@PostMapping("/login")
-	public ResponseEntity<?> socialLogin(@PathVariable String provider, @RequestBody SocialLoginRequest request) {
+	public ResponseEntity<?> socialLogin(@PathVariable String provider, @RequestBody SocialLoginRequest requestDto) {
 		// 1. provider별 id_token 검증(JWK, iss, aud 등)
-		OidcUserPayload payload = idTokenVerifierService.verifyAndExtract(provider, request.idToken());
+		OidcUserPayload payload = idTokenVerifierService.verifyAndExtract(provider, requestDto.idToken(),
+			requestDto.nickname());
 
 		// 2. 유저 정보 추출/회원 처리
 		LoginUser user = userService.upsertSocialUser(payload);

--- a/capturecat-core/src/main/java/com/capturecat/core/api/auth/dto/SocialLoginRequest.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/auth/dto/SocialLoginRequest.java
@@ -1,4 +1,4 @@
 package com.capturecat.core.api.auth.dto;
 
-public record SocialLoginRequest(String idToken) {
+public record SocialLoginRequest(String idToken, String nickname) {
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/auth/IdTokenVerifierService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/auth/IdTokenVerifierService.java
@@ -37,7 +37,7 @@ import com.capturecat.core.support.error.ErrorType;
 public class IdTokenVerifierService {
 	private final Oauth2Properties oauth2Properties;
 
-	public OidcUserPayload verifyAndExtract(String provider, String idToken) {
+	public OidcUserPayload verifyAndExtract(String provider, String idToken, String nickname) {
 		// 공급자 정보 조회
 		Provider providerInfo = oauth2Properties.getProvider().get(provider);
 		Registration registrationInfo = oauth2Properties.getRegistration().get(provider);
@@ -61,7 +61,7 @@ public class IdTokenVerifierService {
 				provider,
 				claims.getSubject(),
 				claims.getStringClaim("email"),
-				extractNickname(provider, claims),
+				extractNickname(claims, provider, nickname),
 				claims.getBooleanClaim("email_verified")
 			);
 		} catch (Exception e) {
@@ -105,12 +105,12 @@ public class IdTokenVerifierService {
 		return claims;
 	}
 
-	private String extractNickname(String provider, JWTClaimsSet claims) throws ParseException {
+	private String extractNickname(JWTClaimsSet claims, String provider, String nickname) throws ParseException {
 		return switch (provider) {
 			case "kakao" -> claims.getStringClaim("nickname");
-			case "apple" -> claims.getStringClaim("fullName");
 			case "google" -> claims.getStringClaim("name");
-			default -> claims.getStringClaim("email");
+			case "apple" -> nickname;
+			default -> claims.getStringClaim("email"); //apple의 경우 requestDto를 통해 받는다.
 		};
 	}
 

--- a/capturecat-core/src/main/java/com/capturecat/core/service/auth/LoginUser.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/auth/LoginUser.java
@@ -27,7 +27,7 @@ public class LoginUser implements UserDetails {
 		this.password = user.getPassword();
 		this.nickname = user.getNickname();
 		this.role = user.getRole();
-		this.tutorialCompleted = user.isTutorialCompleted(); //TODO
+		this.tutorialCompleted = user.isTutorialCompleted();
 	}
 
 	//엑세스 토큰에서 사용자 정보 추출 시 사용

--- a/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerSliceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerSliceTest.java
@@ -56,9 +56,10 @@ class Oauth2AuthControllerSliceTest {
 	@Test
 	void socialLogin_success() throws Exception {
 		// given
-		String provider = "google";
+		String provider = "apple";
 		String idToken = "test-id-token";
-		SocialLoginRequest req = new SocialLoginRequest(idToken);
+		String nickname = "최재량";
+		SocialLoginRequest req = new SocialLoginRequest(idToken, nickname);
 		OidcUserPayload payload =
 			new OidcUserPayload(provider, "1234", "test@test.com", "testNickname", true);
 
@@ -70,7 +71,7 @@ class Oauth2AuthControllerSliceTest {
 		);
 
 		// idTokenVerifierService.verifyAndExtract → payload
-		Mockito.when(idTokenVerifierService.verifyAndExtract(eq(provider), eq(idToken)))
+		Mockito.when(idTokenVerifierService.verifyAndExtract(anyString(), anyString(), any()))
 			.thenReturn(payload);
 		// userService.upsertSocialUser → user
 		Mockito.when(userService.upsertSocialUser(payload)).thenReturn(user);
@@ -96,15 +97,16 @@ class Oauth2AuthControllerSliceTest {
 		// given
 		String provider = "google";
 		String idToken = "bad-id-token";
-		SocialLoginRequest req = new SocialLoginRequest(idToken);
+		String nickname = null;
+		SocialLoginRequest req = new SocialLoginRequest(idToken, nickname);
 
-		Mockito.when(idTokenVerifierService.verifyAndExtract(eq(provider), eq(idToken)))
+		Mockito.when(idTokenVerifierService.verifyAndExtract(anyString(), anyString(), any()))
 			.thenThrow(new CoreException(ErrorType.INVALID_ID_TOKEN));
 
 		// when & then
 		mockMvc.perform(post(REQUEST_PATH, provider)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(req))) //컨트롤러 슬라이스 테스트 시 security config가 load 되지 않아 추가)
+				.content(objectMapper.writeValueAsString(req)))
 			.andExpect(status().isUnauthorized()) // 실제 예외 핸들러에 따라 다를 수 있음
 			.andExpect(jsonPath("$.result").value("ERROR"))
 			.andExpect(jsonPath("$.error").exists());
@@ -113,10 +115,9 @@ class Oauth2AuthControllerSliceTest {
 	private LoginUser buildUser(IdTokenVerifierService.OidcUserPayload payload) {
 		User user = User.builder()
 			.email(payload.email())
-			.provider(payload.provider())
-			.socialId(payload.sub())
 			.role(UserRole.USER)
 			.username(payload.email() != null ? payload.email() : payload.provider() + "_" + payload.sub())
+			.nickname(payload.nickname())
 			.build();
 		return new LoginUser(user);
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/auth/Oauth2AuthControllerTest.java
@@ -51,7 +51,7 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 		// given
 		String provider = "google";
 		String idToken = "test-id-token";
-		SocialLoginRequest request = new SocialLoginRequest(idToken);
+		SocialLoginRequest request = new SocialLoginRequest(idToken, null);
 		OidcUserPayload payload =
 			new OidcUserPayload(provider, "1234", "test@test.com", "testNickname", true);
 		LoginUser user = buildUser(payload);
@@ -60,7 +60,7 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 			TokenType.REFRESH, "refresh.jwt.token"
 		);
 
-		willReturn(payload).given(idTokenVerifierService).verifyAndExtract(provider, idToken);
+		willReturn(payload).given(idTokenVerifierService).verifyAndExtract(provider, idToken, null);
 		willReturn(user).given(userService).upsertSocialUser(payload);
 		willReturn(tokenMap).given(tokenService).issue(user.getUsername(), user.getRole());
 
@@ -74,7 +74,10 @@ public class Oauth2AuthControllerTest extends RestDocsTest {
 					parameterWithName("provider").description("소셜 로그인 제공자 (예: google, apple 등)")
 				),
 				requestFields(
-					fieldWithPath("idToken").type(JsonFieldType.STRING).description("클라이언트에서 받은 ID 토큰")
+					fieldWithPath("idToken").type(JsonFieldType.STRING).description("클라이언트에서 받은 ID 토큰"),
+					fieldWithPath("nickname").type(JsonFieldType.STRING)
+						.optional()
+						.description("apple 로그인 시 fullName 별도 전달")
 				),
 				responseHeaders(
 					headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 액세스 토큰"),

--- a/capturecat-core/src/test/java/com/capturecat/core/service/auth/IdTokenVerifierServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/auth/IdTokenVerifierServiceTest.java
@@ -39,11 +39,13 @@ class IdTokenVerifierServiceTest {
 		provider.setIssuerUri("https://test-issuer.com");
 		provider.setJwkSetUri("https://test-issuer.com/keys");
 		props.getProvider().put("google", provider);
+		props.getProvider().put("apple", provider);
 
 		// 2. Registration 세팅
 		Registration reg = new Registration();
 		reg.setClientId("test-client-id");
 		props.getRegistration().put("google", reg);
+		props.getRegistration().put("apple", reg);
 
 		// 3. 서비스 생성
 		service = Mockito.spy(new IdTokenVerifierService(props));
@@ -79,13 +81,13 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		//when
-		OidcUserPayload payload = service.verifyAndExtract("google", idToken.serialize());
+		OidcUserPayload payload = service.verifyAndExtract("apple", idToken.serialize(), "최재량");
 
 		//then
-		assertThat(payload.provider()).isEqualTo("google");
+		assertThat(payload.provider()).isEqualTo("apple");
 		assertThat(payload.sub()).isEqualTo("mysub");
 		assertThat(payload.email()).isEqualTo("test@test.com");
-		assertThat(payload.nickname()).isEqualTo("testNickname");
+		assertThat(payload.nickname()).isEqualTo("최재량");
 		assertThat(payload.emailVerified()).isTrue();
 	}
 
@@ -107,7 +109,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("google", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize(), null)
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);
@@ -131,7 +133,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("google", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize(), null)
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);
@@ -155,7 +157,7 @@ class IdTokenVerifierServiceTest {
 		Mockito.doNothing().when(service).verifyJwtSignature(Mockito.any(), Mockito.any());
 
 		assertThatThrownBy(() ->
-			service.verifyAndExtract("google", idToken.serialize())
+			service.verifyAndExtract("google", idToken.serialize(), null)
 		).isInstanceOf(CoreException.class)
 			.extracting("errorType")
 			.isEqualTo(ErrorType.INVALID_ID_TOKEN);


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #91

## 📝 작업 내용 (필수)

> 애플 소셜 로그인 시 idToken에 닉네임 정보가 포함되어 있지 않아 별도 수신

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social login now supports submitting a nickname, particularly for Apple login, allowing users to provide their full name during authentication.

* **Bug Fixes**
  * Improved nickname handling for different social login providers to ensure accurate display names.

* **Tests**
  * Updated and expanded test coverage to reflect changes in social login requests and nickname handling, including support for Apple login.

* **Documentation**
  * Enhanced API documentation to clarify the optional use of the nickname field for Apple login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->