### PR TITLE
fix: 이미지 삭제 시 즐겨찾기 외래키 제약 조건 위반 오류 해결

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkRepository.java
@@ -12,4 +12,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
 	Optional<Bookmark> findByUserAndImage(User user, Image image);
 
 	boolean existsByUserAndImage(User user, Image image);
+
+	void deleteByUserAndImage(User user, Image image);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -176,8 +176,9 @@ public class ImageService {
 		image.validateOwnership(user);
 
 		delete(image.getFileName());
-		imageRepository.delete(image);
+		bookmarkRepository.deleteByUserAndImage(user, image);
 		imageTagRepository.deleteAllByImage(image);
+		imageRepository.delete(image);
 	}
 
 	private void validate(MultipartFile file) {
@@ -189,12 +190,7 @@ public class ImageService {
 
 	private UploadItemRequest getMatchingUploadRequest(List<UploadItemRequest> uploadItems, String fileName) {
 		return uploadItems.stream()
-			.filter(i -> {
-				// TODO: 제거
-				System.out.println("i.fileName() = " + i.fileName());
-				System.out.println("fileName = " + fileName);
-				return i.fileName().equals(fileName);
-			})
+			.filter(i -> i.fileName().equals(fileName))
 			.findFirst()
 			.orElseThrow(() -> new CoreException(ErrorType.UPLOAD_METADATA_MISMATCH));
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/service/image/ImageServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/image/ImageServiceTest.java
@@ -4,9 +4,12 @@ import static com.capturecat.core.domain.tag.TagFixture.createTag;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -22,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.capturecat.client.upload.FileUploader;
 import com.capturecat.core.DummyObject;
@@ -37,6 +41,7 @@ import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorCode;
 import com.capturecat.core.support.error.ErrorType;
 
 @ExtendWith(MockitoExtension.class)
@@ -105,8 +110,8 @@ class ImageServiceTest {
 		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
 		given(imageRepository.searchByUser(eq(user), eq(true), any(Pageable.class)))
 			.willReturn(new SliceImpl<>(List.of(
-					new ImageInfo(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), true,
-						List.of(createTag(1L, "tag1"), createTag(2L, "tag2"))))));
+				new ImageInfo(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), true,
+					List.of(createTag(1L, "tag1"), createTag(2L, "tag2"))))));
 
 		// when
 		var response = imageService.getImagesWithTags(new LoginUser(user), true, PageRequest.of(0, 10));
@@ -120,8 +125,7 @@ class ImageServiceTest {
 	@Test
 	void getImagesWithTags_hasTagsIsFalse() {
 		// given
-		given(userRepository.findByUsername(anyString()))
-			.willReturn(Optional.of(user));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
 		given(imageRepository.searchByUser(eq(user), eq(false), any(Pageable.class)))
 			.willReturn(new SliceImpl<>(List.of(
 				new ImageInfo(1L, "cat.jpg", "http://example.com/cat.jpg", LocalDate.now(), true,
@@ -146,5 +150,46 @@ class ImageServiceTest {
 		assertThatThrownBy(() -> imageService.getImagesWithTags(new LoginUser(user), false, PageRequest.of(0, 10)))
 			.isInstanceOf(CoreException.class)
 			.hasMessageContaining(ErrorType.USER_NOT_FOUND.getCode().getMessage());
+	}
+
+	@Test
+	void removeImage() {
+		// given
+		var image = DummyObject.newMockUserImage(user);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(imageRepository.findById(anyLong())).willReturn(Optional.of(image));
+		willDoNothing().given(fileUploader).delete(eq(image.getFileName()));
+		willDoNothing().given(bookmarkRepository).deleteByUserAndImage(any(), any());
+		willDoNothing().given(imageTagRepository).deleteAllByImage(any());
+		willDoNothing().given(imageRepository).delete(any());
+
+		// when
+		imageService.removeImages(1L, new LoginUser(user));
+
+		// then
+		verify(fileUploader).delete(eq(image.getFileName()));
+		verify(bookmarkRepository).deleteByUserAndImage(eq(user), eq(image));
+		verify(imageTagRepository).deleteAllByImage(eq(image));
+		verify(imageRepository).delete(eq(image));
+	}
+
+	@Test
+	void removeImageFail_IsNotOwnerShip() {
+		// given
+		var anotherUser = DummyObject.newUser("anotherUser");
+		var image = DummyObject.newMockUserImage(user);
+
+		ReflectionTestUtils.setField(user, "id", 1L);
+		ReflectionTestUtils.setField(anotherUser, "id", 2L);
+		ReflectionTestUtils.setField(image, "id", 1L);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(anotherUser));
+		given(imageRepository.findById(anyLong())).willReturn(Optional.of(image));
+
+		// when & then
+		assertThatThrownBy(() -> imageService.removeImages(1L, new LoginUser(anotherUser)))
+			.isInstanceOf(CoreException.class)
+			.hasMessage(ErrorCode.IMAGE_ACCESS_DENIED.getMessage());
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #94 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

즐겨찾기 추가로 인해 이미지 삭제 시 외래키 제약 조건을 위반하고 있었습니다. 그래서 이미지에 대한 즐겨찾기 삭제를 먼저 진행하도록 추가했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the image removal process to ensure bookmarks are deleted before associated image tags and the image itself.
  * Removed unnecessary debug output during image upload request matching.

* **Tests**
  * Added tests to verify successful image removal by owners and to ensure proper error handling when non-owners attempt removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->