### PR TITLE
feat: 태그 삭제

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -77,3 +77,7 @@ include::{snippets}/errorCode/withdraw/error-codes.adoc[]
 [[튜토리얼-완료-업데이트]]
 === 튜토리얼 완료 업데이트
 include::{snippets}/errorCode/tutorialComplete/error-codes.adoc[]
+
+[[태그-삭제]]
+=== 태그 삭제
+include::{snippets}/errorCode/deleteTag/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/tag.adoc
+++ b/capturecat-core/src/docs/asciidoc/tag.adoc
@@ -32,3 +32,14 @@ operation::getMostUsedTags[snippets='curl-request,http-request,query-parameters,
 많이 사용된 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#많이-사용된-태그-조회, 많이 사용된 태그 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+[[태그-삭제]]
+=== 태그 삭제
+===== 성공
+operation::deleteTag[snippets='curl-request,http-request,query-parameters,http-response,response-fields']
+
+===== 실패
+태그 삭제가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#태그-삭제, 태그 삭제 API에서 발생할 수 있는 에러>>를 살펴보세요.
+

--- a/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/tag/TagController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +46,10 @@ public class TagController {
 	public ApiResponse<CursorResponse<TagResponse>> getMostUsedTags(@AuthenticationPrincipal LoginUser loginUser,
 			@PageableDefault Pageable pageable) {
 		return ApiResponse.success(tagService.getMostUsedTags(loginUser, pageable));
+	}
+
+	@DeleteMapping("/{tagId}")
+	public ApiResponse<TagResponse> delete(@AuthenticationPrincipal LoginUser loginUser, @PathVariable Long tagId) {
+		return ApiResponse.success(tagService.deleteTag(loginUser, tagId));
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTag.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTag.java
@@ -33,5 +33,4 @@ public class ImageTag extends BaseTimeEntity {
 		this.image = image;
 		this.tag = tag;
 	}
-
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import com.capturecat.core.domain.image.Image;
+import com.capturecat.core.domain.user.User;
 
 public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
@@ -21,4 +23,8 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 	long countByImage(Image image);
 
 	void deleteAllByImage(Image image);
+
+	@Modifying
+	@Query("DELETE FROM ImageTag it WHERE it.tag = :tag AND it.image.user = :user")
+	void deleteTagAndUser(Tag tag, User user);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -28,5 +28,5 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
 	@Modifying
 	@Query("DELETE FROM ImageTag it WHERE it.tag = :tag AND it.image.user = :user")
-	void deleteTagAndUser(Tag tag, User user);
+	void deleteByTagAndUser(Tag tag, User user);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -22,6 +22,8 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
 	long countByImage(Image image);
 
+	boolean existsByTag(Tag tag);
+
 	void deleteAllByImage(Image image);
 
 	@Modifying

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.tag.Tag;
 import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.User;
@@ -27,6 +28,7 @@ public class TagService {
 
 	private final TagRepository tagRepository;
 	private final UserRepository userRepository;
+	private final ImageTagRepository imageTagRepository;
 
 	@Transactional(readOnly = true)
 	public CursorResponse<TagResponse> getTags(LoginUser loginUser, Pageable pageable) {
@@ -41,6 +43,18 @@ public class TagService {
 	@Transactional(readOnly = true)
 	public CursorResponse<TagResponse> getMostUsedTags(LoginUser loginUser, Pageable pageable) {
 		return searchTagsWithCursor(loginUser, user -> tagRepository.searchMostUsedTagsByUser(user, pageable));
+	}
+
+	@Transactional
+	public TagResponse deleteTag(LoginUser loginUser, Long tagId) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		Tag tag = tagRepository.findById(tagId)
+			.orElseThrow(() -> new CoreException(ErrorType.TAG_NOT_FOUND));
+
+		imageTagRepository.deleteTagAndUser(tag, user);
+
+		return TagResponse.from(tag);
 	}
 
 	private CursorResponse<TagResponse> searchTagsWithCursor(LoginUser loginUser,

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -54,6 +54,10 @@ public class TagService {
 
 		imageTagRepository.deleteTagAndUser(tag, user);
 
+		if (!imageTagRepository.existsByTag((tag))) {
+			tagRepository.delete(tag);
+		}
+
 		return TagResponse.from(tag);
 	}
 

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/TagService.java
@@ -52,7 +52,7 @@ public class TagService {
 		Tag tag = tagRepository.findById(tagId)
 			.orElseThrow(() -> new CoreException(ErrorType.TAG_NOT_FOUND));
 
-		imageTagRepository.deleteTagAndUser(tag, user);
+		imageTagRepository.deleteByTagAndUser(tag, user);
 
 		if (!imageTagRepository.existsByTag((tag))) {
 			tagRepository.delete(tag);

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeDocumentTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeDocumentTest.java
@@ -1,0 +1,40 @@
+package com.capturecat.core.api.error;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.http.HttpStatus;
+
+import io.restassured.http.ContentType;
+
+import com.capturecat.core.support.error.ErrorType;
+import com.capturecat.test.api.RestDocsTest;
+import com.capturecat.test.snippet.ErrorCodeDescriptor;
+import com.capturecat.test.snippet.ErrorCodeSnippet;
+
+public abstract class ErrorCodeDocumentTest extends RestDocsTest {
+
+	private ErrorCodeController errorCodeController;
+
+	@BeforeEach
+	void setUp() {
+		errorCodeController = new ErrorCodeController();
+		mockMvc = mockController(errorCodeController);
+	}
+
+	public void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {
+		given().contentType(ContentType.JSON)
+			.when().get("/v1/error-codes")
+			.then().status(HttpStatus.OK)
+			.apply(document(identifier, new ErrorCodeSnippet(errorCodeDescriptors)));
+	}
+
+	public List<ErrorCodeDescriptor> generateErrorCodeDescriptors(ErrorType... errorTypes) {
+		return Stream.of(errorTypes)
+			.map(e -> new ErrorCodeDescriptor(e.getStatus().value(), e.getCode().name(), e.getCode().getMessage()))
+			.toList();
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import java.util.List;
@@ -118,6 +119,28 @@ class TagControllerTest extends RestDocsTest {
 					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("가장 많이 사용된 태그 목록"),
 					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("태그 이름"),
+					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
+	}
+
+	@Test
+	void 태그_삭제() {
+		// given
+		BDDMockito.given(tagService.deleteTag(any(), any()))
+			.willReturn(new TagResponse(1L, "tag"));
+
+		// when & then
+		given().contentType(ContentType.JSON)
+			.when().delete("/v1/tags/{tagId}", 1L)
+			.then().status(HttpStatus.OK)
+			.apply(document("deleteTag", requestPreprocessor(), responsePreprocessor(),
+				pathParameters(
+					parameterWithName("tagId").description("삭제할 태그의 ID")
+				),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("삭제된 태그 정보"),
+					fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("태그 ID"),
+					fieldWithPath("data.name").type(JsonFieldType.STRING).description("태그 이름"),
 					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/tag/TagErrorCodeControllerTest.java
@@ -1,0 +1,20 @@
+package com.capturecat.core.api.tag;
+
+import static com.capturecat.core.support.error.ErrorType.TAG_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.USER_NOT_FOUND;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.capturecat.core.api.error.ErrorCodeDocumentTest;
+import com.capturecat.test.snippet.ErrorCodeDescriptor;
+
+class TagErrorCodeControllerTest extends ErrorCodeDocumentTest {
+
+	@Test
+	void 태그_삭제_에러_코드_문서화() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND, TAG_NOT_FOUND);
+		generateErrorDocs("errorCode/deleteTag", errorCodeDescriptors);
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
@@ -59,6 +59,31 @@ class ImageTagRepositoryTest {
 	}
 
 	@Test
+	void 한_사용자의_여러_이미지에서_해당_태그가_모두_삭제된다() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("multiUser"));
+		var imageA = imageRepository.save(DummyObject.newMockUserImage(user));
+		var imageB = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag = tagRepository.save(TagFixture.createTag("java"));
+
+		imageTagRepository.save(new ImageTag(imageA, tag));
+		imageTagRepository.save(new ImageTag(imageB, tag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		imageTagRepository.deleteTagAndUser(tag, user);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(imageTagRepository.findByImage(imageA)).isEmpty();
+		assertThat(imageTagRepository.findByImage(imageB)).isEmpty();
+	}
+
+	@Test
 	void 다른_사용자의_태그는_삭제되지_않는다() {
 		// given
 		var user1 = userRepository.save(DummyObject.newUser("testUser1"));

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.capturecat.core.domain.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.config.JpaAuditingConfig;
+import com.capturecat.core.config.QueryDslConfig;
+import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.user.UserRepository;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class ImageTagRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@Autowired
+	private ImageTagRepository imageTagRepository;
+
+	@Autowired
+	private TagRepository tagRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void 태그를_삭제한다() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("testUser"));
+		var image = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag = tagRepository.save(TagFixture.createTag("java"));
+		imageTagRepository.save(new ImageTag(image, tag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		imageTagRepository.deleteTagAndUser(tag, user);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		List<ImageTag> result = imageTagRepository.findByImage(image);
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void 다른_사용자의_태그는_삭제되지_않는다() {
+		// given
+		var user1 = userRepository.save(DummyObject.newUser("testUser1"));
+		var user2 = userRepository.save(DummyObject.newUser("testUser2"));
+
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user1));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user2));
+
+		var tag = tagRepository.save(TagFixture.createTag("java"));
+
+		imageTagRepository.save(new ImageTag(image1, tag));
+		imageTagRepository.save(new ImageTag(image2, tag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		imageTagRepository.deleteTagAndUser(tag, user1);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		List<ImageTag> user1Result = imageTagRepository.findByImage(image1);
+		List<ImageTag> user2Result = imageTagRepository.findByImage(image2);
+
+		assertThat(user1Result).isEmpty();
+		assertThat(user2Result).hasSize(1);
+		assertThat(user2Result.get(0).getImage().getUser()).isEqualTo(user2);
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
@@ -48,7 +48,7 @@ class ImageTagRepositoryTest {
 		entityManager.clear();
 
 		// when
-		imageTagRepository.deleteTagAndUser(tag, user);
+		imageTagRepository.deleteByTagAndUser(tag, user);
 
 		entityManager.flush();
 		entityManager.clear();
@@ -73,7 +73,7 @@ class ImageTagRepositoryTest {
 		entityManager.clear();
 
 		// when
-		imageTagRepository.deleteTagAndUser(tag, user);
+		imageTagRepository.deleteByTagAndUser(tag, user);
 
 		entityManager.flush();
 		entityManager.clear();
@@ -101,7 +101,7 @@ class ImageTagRepositoryTest {
 		entityManager.clear();
 
 		// when
-		imageTagRepository.deleteTagAndUser(tag, user1);
+		imageTagRepository.deleteByTagAndUser(tag, user1);
 
 		entityManager.flush();
 		entityManager.clear();

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagFixture.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagFixture.java
@@ -4,6 +4,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class TagFixture {
 
+	public static Tag createTag(String name) {
+		return new Tag(name);
+	}
+
 	public static Tag createTag(Long id, String name) {
 		Tag tag = new Tag(name);
 		ReflectionTestUtils.setField(tag, "id", id);

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -136,8 +136,7 @@ class TagServiceTest {
 		var loginUser = new LoginUser(user);
 		var tag = TagFixture.createTag(1L, "java");
 
-		given(userRepository.findByUsername(loginUser.getUsername()))
-			.willThrow(new CoreException(ErrorType.USER_NOT_FOUND));
+		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(() -> tagService.deleteTag(loginUser, tag.getId()))
@@ -156,7 +155,7 @@ class TagServiceTest {
 		var tag = TagFixture.createTag(1L, "java");
 
 		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
-		given(tagRepository.findById(eq(tag.getId()))).willThrow(new CoreException(ErrorType.TAG_NOT_FOUND));
+		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(() -> tagService.deleteTag(loginUser, tag.getId()))

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -92,7 +92,7 @@ class TagServiceTest {
 
 		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
 		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.of(tag));
-		willDoNothing().given(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		willDoNothing().given(imageTagRepository).deleteByTagAndUser(eq(tag), eq(user));
 		given(imageTagRepository.existsByTag(tag)).willReturn(true);
 
 		// when
@@ -102,7 +102,7 @@ class TagServiceTest {
 		assertThat(response.id()).isEqualTo(tag.getId());
 		assertThat(response.name()).isEqualTo(tag.getName());
 
-		verify(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		verify(imageTagRepository).deleteByTagAndUser(eq(tag), eq(user));
 		verify(tagRepository, never()).delete(eq(tag));
 	}
 
@@ -115,7 +115,7 @@ class TagServiceTest {
 
 		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
 		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.of(tag));
-		willDoNothing().given(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		willDoNothing().given(imageTagRepository).deleteByTagAndUser(eq(tag), eq(user));
 		given(imageTagRepository.existsByTag(tag)).willReturn(false);
 
 		// when
@@ -125,7 +125,7 @@ class TagServiceTest {
 		assertThat(response.id()).isEqualTo(tag.getId());
 		assertThat(response.name()).isEqualTo(tag.getName());
 
-		verify(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		verify(imageTagRepository).deleteByTagAndUser(eq(tag), eq(user));
 		verify(tagRepository).delete(eq(tag));
 	}
 
@@ -144,7 +144,7 @@ class TagServiceTest {
 			.isInstanceOf(CoreException.class)
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.USER_NOT_FOUND);
 
-		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
+		verify(imageTagRepository, never()).deleteByTagAndUser(eq(tag), eq(user));
 		verify(tagRepository, never()).delete(eq(tag));
 	}
 
@@ -163,7 +163,7 @@ class TagServiceTest {
 			.isInstanceOf(CoreException.class)
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.TAG_NOT_FOUND);
 
-		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
+		verify(imageTagRepository, never()).deleteByTagAndUser(eq(tag), eq(user));
 		verify(tagRepository, never()).delete(eq(tag));
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.data.domain.PageRequest.of;
 
@@ -21,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 
 import com.capturecat.core.DummyObject;
+import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.tag.TagFixture;
 import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.UserRepository;
@@ -36,6 +39,9 @@ class TagServiceTest {
 
 	@Mock
 	private UserRepository userRepository;
+
+	@Mock
+	private ImageTagRepository imageTagRepository;
 
 	@InjectMocks
 	private TagService tagService;
@@ -75,5 +81,62 @@ class TagServiceTest {
 		assertThatThrownBy(() -> tagService.getMostUsedTags(loginUser, of(0, 10)))
 			.isInstanceOf(CoreException.class)
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.USER_NOT_FOUND);
+	}
+
+	@Test
+	void 태그를_삭제한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var loginUser = new LoginUser(user);
+		var tag = TagFixture.createTag(1L, "java");
+
+		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
+		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.of(tag));
+		willDoNothing().given(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+
+		// when
+		var response = tagService.deleteTag(loginUser, tag.getId());
+
+		// then
+		assertThat(response.id()).isEqualTo(tag.getId());
+		assertThat(response.name()).isEqualTo(tag.getName());
+
+		verify(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+	}
+
+	@Test
+	void 태그_삭제_시_회원이_존재하지_않으면_실패한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var loginUser = new LoginUser(user);
+		var tag = TagFixture.createTag(1L, "java");
+
+		given(userRepository.findByUsername(loginUser.getUsername()))
+			.willThrow(new CoreException(ErrorType.USER_NOT_FOUND));
+
+		// when & then
+		assertThatThrownBy(() -> tagService.deleteTag(loginUser, tag.getId()))
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue("errorType", ErrorType.USER_NOT_FOUND);
+
+		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
+	}
+
+	@Test
+	void 태그_삭제_시_태그가_존재하지_않으면_실패한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var loginUser = new LoginUser(user);
+		var tag = TagFixture.createTag(1L, "java");
+
+		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
+		given(tagRepository.findById(eq(tag.getId()))).willThrow(new CoreException(ErrorType.TAG_NOT_FOUND));
+
+		// when & then
+		assertThatThrownBy(() -> tagService.deleteTag(loginUser, tag.getId()))
+			.isInstanceOf(CoreException.class)
+			.hasFieldOrPropertyWithValue("errorType", ErrorType.TAG_NOT_FOUND);
+
+		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/TagServiceTest.java
@@ -93,6 +93,7 @@ class TagServiceTest {
 		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
 		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.of(tag));
 		willDoNothing().given(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		given(imageTagRepository.existsByTag(tag)).willReturn(true);
 
 		// when
 		var response = tagService.deleteTag(loginUser, tag.getId());
@@ -102,6 +103,30 @@ class TagServiceTest {
 		assertThat(response.name()).isEqualTo(tag.getName());
 
 		verify(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		verify(tagRepository, never()).delete(eq(tag));
+	}
+
+	@Test
+	void 태그를_삭제_시_더_이상_사용되지_않으면_Tag_엔티티도_함께_삭제한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var loginUser = new LoginUser(user);
+		var tag = TagFixture.createTag(1L, "java");
+
+		given(userRepository.findByUsername(loginUser.getUsername())).willReturn(Optional.of(user));
+		given(tagRepository.findById(eq(tag.getId()))).willReturn(Optional.of(tag));
+		willDoNothing().given(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		given(imageTagRepository.existsByTag(tag)).willReturn(false);
+
+		// when
+		var response = tagService.deleteTag(loginUser, tag.getId());
+
+		// then
+		assertThat(response.id()).isEqualTo(tag.getId());
+		assertThat(response.name()).isEqualTo(tag.getName());
+
+		verify(imageTagRepository).deleteTagAndUser(eq(tag), eq(user));
+		verify(tagRepository).delete(eq(tag));
 	}
 
 	@Test
@@ -120,6 +145,7 @@ class TagServiceTest {
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.USER_NOT_FOUND);
 
 		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
+		verify(tagRepository, never()).delete(eq(tag));
 	}
 
 	@Test
@@ -138,5 +164,6 @@ class TagServiceTest {
 			.hasFieldOrPropertyWithValue("errorType", ErrorType.TAG_NOT_FOUND);
 
 		verify(imageTagRepository, never()).deleteTagAndUser(eq(tag), eq(user));
+		verify(tagRepository, never()).delete(eq(tag));
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #78 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그 삭제 API를 구현했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

### 문제 
요즘 고민되는 건 '태그' 라는 용어에 대해 저희(백엔드)와 타 직군 팀원분들 사이에 개념적 차이가 있을 수 있겠다는 생각이 들었습니다.

- 타 직군 팀원들의 의미: '이미지에 붙어있는 꼬리표' (#강아지, #노을) → 데이터 모델의 ImageTag (관계)
- 백엔드의 의미: '강아지'나 '노을'이라는 독립적인 단어/개념 그 자체 → 데이터 모델의 Tag (실체)

이런 고민 때문에 어느 패키지에 코드를 작성해야 할지 고민이 되는 상황입니다.

### 해결 방안
이러한 혼란을 줄이고 각 코드의 책임을 명확히 하기 위해, 다음과 같이 용어를 명확히 구분하여 사용하는건 어떤가요?

- Tag (태그): '강아지'와 같은 독립적인 명사/개념을 의미합니다.
  - 책임: tag 패키지 (또는 컨텍스트)에서 태그 자체의 생성, 조회, 관리 등을 담당합니다.
- Tagging (태깅): 이미지에 태그를 `붙이는 행위` 또는 `붙은 상태`를 의미합니다.
  - 책임: image 패키지 (또는 컨텍스트)에서 이미지의 일부로서 '태깅'을 추가/삭제하는 것을 담당합니다. '태깅'은 이미지 없이는 존재할 수 없는 종속적인 개념이기 때문입니다.

이처럼 '이미지에 태그를 태깅한다' 로 개념을 정립하면, 각 도메인의 역할과 책임이 명확해져 코드를 더 적절한 위치에 작성할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to delete tags via a new API endpoint.
  * Extended API documentation to include tag deletion operations and related error codes.

* **Bug Fixes**
  * None.

* **Documentation**
  * Updated and expanded documentation to cover tag deletion, including success and error scenarios.
  * Added automated tests and documentation for error codes related to tag deletion.

* **Tests**
  * Introduced comprehensive tests for tag deletion, including service, controller, and repository layers.
  * Added tests to verify correct deletion behavior and error handling for various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->