### PR TITLE
feat: 사용자 정보 조회

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -74,6 +74,10 @@ include::{snippets}/errorCode/logout/error-codes.adoc[]
 === 회원탈퇴
 include::{snippets}/errorCode/withdraw/error-codes.adoc[]
 
+[[사용자정보조회]]
+=== 사용자정보조회
+include::{snippets}/errorCode/userInfo/error-codes.adoc[]
+
 [[튜토리얼-완료-업데이트]]
 === 튜토리얼 완료 업데이트
 include::{snippets}/errorCode/tutorialComplete/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/user.adoc
+++ b/capturecat-core/src/docs/asciidoc/user.adoc
@@ -24,3 +24,16 @@ operation::withdraw[snippets='curl-request,http-request,request-headers,http-res
 회원 탈퇴가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#회원탈퇴, 회원 탈퇴 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+
+[[사용자-정보-조회]]
+=== 사용자 정보 조회
+JWT 엑세스 토큰의 사용자 정보를 조회합니다.
+
+==== 성공
+operation::userInfo[snippets='curl-request,http-request,request-headers,http-response,response-fields']
+
+==== 실패
+사용자 정보 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#사용자정보조회, 회원 탈퇴 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/docs/asciidoc/user.adoc
+++ b/capturecat-core/src/docs/asciidoc/user.adoc
@@ -36,4 +36,4 @@ operation::userInfo[snippets='curl-request,http-request,request-headers,http-res
 ==== 실패
 사용자 정보 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
-<<error-codes#사용자정보조회, 회원 탈퇴 API에서 발생할 수 있는 에러>>를 살펴보세요.
+<<error-codes#사용자정보조회, 사용자 정보 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
 import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
+import com.capturecat.core.api.user.dto.UserRespDto;
+import com.capturecat.core.api.user.dto.UserRespDto.InfoRespDto;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
 import com.capturecat.core.support.response.ApiResponse;
@@ -46,5 +49,14 @@ public class UserController {
 	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser) {
 		String resultMessage = userService.withdraw(loginUser);
 		return ApiResponse.success(resultMessage);
+	}
+
+	/**
+	 * 회원 정보 조회
+	 */
+	@GetMapping("/info")
+	public ApiResponse<InfoRespDto> join(@AuthenticationPrincipal LoginUser loginUser) {
+		InfoRespDto infoRespDto = userService.getUserInfo(loginUser.getUsername());
+		return ApiResponse.success(infoRespDto);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
 import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
-import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.api.user.dto.UserRespDto.InfoRespDto;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
@@ -55,7 +54,7 @@ public class UserController {
 	 * 회원 정보 조회
 	 */
 	@GetMapping("/info")
-	public ApiResponse<InfoRespDto> join(@AuthenticationPrincipal LoginUser loginUser) {
+	public ApiResponse<InfoRespDto> getUserInfo(@AuthenticationPrincipal LoginUser loginUser) {
 		InfoRespDto infoRespDto = userService.getUserInfo(loginUser.getUsername());
 		return ApiResponse.success(infoRespDto);
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserRespDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserRespDto.java
@@ -1,0 +1,25 @@
+package com.capturecat.core.api.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import com.capturecat.core.domain.user.User;
+
+/** 회원 관련 응답 DTO */
+public class UserRespDto {
+
+	/** 회원 정보 응답 DTO */
+	@Getter
+	@Setter
+	public static class InfoRespDto {
+		private String email;
+		private String nickname;
+		private boolean tutorialCompleted;
+
+		public InfoRespDto(User user) {
+			this.email = user.getUsername();
+			this.nickname = user.getNickname();
+			this.tutorialCompleted = user.isTutorialCompleted();
+		}
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
 import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
+import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
@@ -127,6 +128,15 @@ public class UserService {
 		userRepository.delete(user);
 
 		return resultMessage.toString();
+	}
+
+	/**
+	 * 사용자 정보 조회
+	 */
+	public UserRespDto.InfoRespDto getUserInfo(String username) {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		return new UserRespDto.InfoRespDto(user);
 	}
 
 	private User buildUser(OidcUserPayload payload) {

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -146,6 +146,12 @@ class ErrorCodeControllerTest extends RestDocsTest {
 		generateErrorDocs("errorCode/withdraw", errorCodeDescriptors);
 	}
 
+	@Test
+	void 사용자_정보_조회_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/userInfo", errorCodeDescriptors);
+	}
+
 	private void generateErrorDocs(String identifier, List<ErrorCodeDescriptor> errorCodeDescriptors) {
 		given().contentType(ContentType.JSON)
 			.when().get("/v1/error-codes")

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
@@ -1,18 +1,13 @@
 package com.capturecat.core.api.user;
 
 import static com.capturecat.test.api.RestDocsUtil.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -21,7 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.restassured.http.ContentType;
 
+import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.config.jwt.JwtUtil;
+import com.capturecat.core.domain.user.User;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
 import com.capturecat.test.api.RestDocsTest;
@@ -37,7 +34,6 @@ class UserControllerTest extends RestDocsTest {
 
 	private UserService userService;
 
-
 	@BeforeEach
 	void setUp() {
 		userService = mock(UserService.class);
@@ -51,7 +47,8 @@ class UserControllerTest extends RestDocsTest {
 		willDoNothing().given(userService).updateTutorialCompleted(any(LoginUser.class));
 
 		// when & then
-		given().header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
+		given()
+			.header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
 			.contentType(ContentType.JSON)
 			.when().post(URL_PREFIX + "/tutorialComplete")
 			.then().status(HttpStatus.OK)
@@ -66,13 +63,17 @@ class UserControllerTest extends RestDocsTest {
 	@Test
 	void 회원_탈퇴() {
 		// given
-		willReturn("").given(userService).withdraw(any(LoginUser.class));
+		willReturn("소셜(google) 연결 해지 성공").given(userService).withdraw(any(LoginUser.class));
 
 		// when & then
-		given().header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
+		given()
+			.header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
 			.contentType(ContentType.JSON)
-			.when().delete(URL_PREFIX + "/withdraw")
-			.then().status(HttpStatus.OK)
+			.when()
+			.delete(URL_PREFIX + "/withdraw")
+			.then()
+			.log().all() //요청/응답 전체 출력
+			.status(HttpStatus.OK)
 			.apply(document("withdraw", requestPreprocessor(), responsePreprocessor(),
 				requestHeaders(
 					headerWithName(HttpHeaders.AUTHORIZATION)
@@ -83,4 +84,34 @@ class UserControllerTest extends RestDocsTest {
 				)));
 	}
 
+	@Test
+	void 사용자_정보_조회() {
+		// given
+		User user = User.builder()
+			.username("test@email.com")
+			.nickname("testNickname")
+			.build();
+		user.tutorialComplete();
+		UserRespDto.InfoRespDto infoRespDto = new UserRespDto.InfoRespDto(user);
+		willReturn(infoRespDto).given(userService).getUserInfo(any());
+
+		// when & then
+		given()
+			.header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
+			.contentType(ContentType.JSON)
+			.when()
+			.get(URL_PREFIX + "/info")
+			.then()
+			.status(HttpStatus.OK)
+			.apply(document("userInfo", requestPreprocessor(), responsePreprocessor(),
+				requestHeaders(
+					headerWithName(HttpHeaders.AUTHORIZATION)
+						.description("유효한 Access 토큰")),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과 (예: SUCCESS)"),
+					fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("닉네임"),
+					fieldWithPath("data.tutorialCompleted").type(JsonFieldType.BOOLEAN).description("튜토리얼(시작하기) 완료 여부")
+				)));
+	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #105 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 사용자 정보 조회 API 입니다. 엑세스 토큰에서 username을 추출해서 조회 후 반환합니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve user information, including email, nickname, and tutorial completion status.
  * Updated API documentation to include details for the new user information retrieval endpoint.
  * Added a new section in the error codes documentation for user information retrieval errors.

* **Bug Fixes**
  * Improved formatting and logging in user-related test cases.

* **Tests**
  * Added tests for the new user information retrieval endpoint.
  * Added tests for error codes related to user information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->