### PR TITLE
feat: 탈퇴 사유 수집

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
 	 */
 	@DeleteMapping("/withdraw")
 	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser,
-		@RequestBody WithdrawReqDto req, BindingResult bindingResult) {
+		@RequestBody @Valid WithdrawReqDto req, BindingResult bindingResult) {
 		String resultMessage = userService.withdraw(loginUser, req.getReason().trim());
 		return ApiResponse.success(resultMessage);
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -50,8 +50,8 @@ public class UserController {
 	 */
 	@DeleteMapping("/withdraw")
 	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser,
-		@RequestBody WithdrawReqDto req) {
-		String resultMessage = userService.withdraw(loginUser, req.getReason());
+		@RequestBody WithdrawReqDto req, BindingResult bindingResult) {
+		String resultMessage = userService.withdraw(loginUser, req.getReason().trim());
 		return ApiResponse.success(resultMessage);
 	}
 

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -13,9 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.capturecat.core.api.user.dto.UserReqDto;
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
-import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
+import com.capturecat.core.api.user.dto.UserReqDto.WithdrawReqDto;
+import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.api.user.dto.UserRespDto.InfoRespDto;
+import com.capturecat.core.api.user.dto.UserRespDto.JoinRespDto;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.user.UserService;
 import com.capturecat.core.support.response.ApiResponse;
@@ -43,10 +46,12 @@ public class UserController {
 	 * 탈퇴 API
 	 * 1) 소셜 로그인 연결 해제
 	 * 2) 회원 정보 삭제
+	 * 3) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
 	 */
 	@DeleteMapping("/withdraw")
-	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser) {
-		String resultMessage = userService.withdraw(loginUser);
+	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser,
+		@RequestBody WithdrawReqDto req) {
+		String resultMessage = userService.withdraw(loginUser, req.getReason());
 		return ApiResponse.success(resultMessage);
 	}
 

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserController.java
@@ -45,8 +45,8 @@ public class UserController {
 	/**
 	 * 탈퇴 API
 	 * 1) 소셜 로그인 연결 해제
-	 * 2) 회원 정보 삭제
-	 * 3) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
+	 * 2) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
+	 * 3) 회원 및 관련 데이터 삭제
 	 */
 	@DeleteMapping("/withdraw")
 	public ApiResponse<?> withdraw(@AuthenticationPrincipal LoginUser loginUser,

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
@@ -56,6 +56,7 @@ public class UserReqDto {
 	@Getter
 	@Setter
 	public static class WithdrawReqDto {
+		@Size(max = 500, message = "탈퇴 사유는 500자 이내로 작성해주세요.")
 		private String reason;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserReqDto.java
@@ -2,12 +2,10 @@ package com.capturecat.core.api.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -45,19 +43,6 @@ public class UserReqDto {
 		}
 	}
 
-	/** 회원 가입 응답 DTO */
-	@Getter
-	@Setter
-	public static class JoinRespDto {
-		private Long id;
-		private String username;
-
-		public JoinRespDto(User user) {
-			this.id = user.getId();
-			this.username = user.getUsername();
-		}
-	}
-
 	/** 로그인 요청 DTO */
 	@Getter
 	@Setter
@@ -66,12 +51,10 @@ public class UserReqDto {
 		private String password;
 	}
 
-	/** 로그인 응답 DTO */
+	/** 탈퇴 사유 DTO */
 	@Getter
 	@Setter
-	@AllArgsConstructor
-	public static class LoginRespDto {
-		private String accessToken;
-		private String refreshToken;
+	public static class WithdrawReqDto {
+		private String reason;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserRespDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/dto/UserRespDto.java
@@ -1,5 +1,6 @@
 package com.capturecat.core.api.user.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,6 +21,28 @@ public class UserRespDto {
 			this.email = user.getUsername();
 			this.nickname = user.getNickname();
 			this.tutorialCompleted = user.isTutorialCompleted();
+		}
+	}
+
+	/** 로그인 응답 DTO */
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	public static class LoginRespDto {
+		private String accessToken;
+		private String refreshToken;
+	}
+
+	/** 회원 가입 응답 DTO */
+	@Getter
+	@Setter
+	public static class JoinRespDto {
+		private Long id;
+		private String username;
+
+		public JoinRespDto(User user) {
+			this.id = user.getId();
+			this.username = user.getUsername();
 		}
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkRepository.java
@@ -15,5 +15,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
 
 	void deleteByUserAndImage(User user, Image image);
 
-	void deleteByUser(User user);
+	void deleteByUserId(Long userId);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageRepository.java
@@ -3,9 +3,15 @@ package com.capturecat.core.domain.image;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.capturecat.core.domain.user.User;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageCustomRepository {
 	List<Image> findByUser(User user);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("DELETE FROM Image i WHERE i.user.id = :userId")
+	int deleteAllImagesByUserId(Long userId);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -29,4 +29,8 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 	@Modifying
 	@Query("DELETE FROM ImageTag it WHERE it.tag = :tag AND it.image.user = :user")
 	void deleteByTagAndUser(Tag tag, User user);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("DELETE FROM ImageTag it WHERE it.image.id IN (SELECT i.id FROM Image i WHERE i.user.id = :userId)")
+	void deleteAllTagsByUserId(Long userId);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/S3CleanupStatus.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/S3CleanupStatus.java
@@ -1,0 +1,7 @@
+package com.capturecat.core.domain.user;
+
+public enum S3CleanupStatus {
+	PENDING,   // 기본값: 탈퇴 직후
+	DONE,      // 배치가 정상 처리
+	FAILED     // 배치 실패(재시도 대상)
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLog.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLog.java
@@ -26,7 +26,7 @@ import com.capturecat.core.domain.BaseTimeEntity;
 	indexes = {
 		@Index(name = "idx_withdraw_log_user_id", columnList = "user_id"),
 		@Index(name = "idx_withdraw_log_created_date", columnList = "created_date"),
-		@Index(name = "idx_withdraw_log_s3_status", columnList = "s3_cleanup_status, created_date")
+		@Index(name = "idx_withdraw_log_cleanup_status", columnList = "image_cleanup_status, created_date")
 	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -43,18 +43,18 @@ public class WithdrawLog extends BaseTimeEntity {
 	@Column(columnDefinition = "text")
 	private String reason;
 
-	/** S3 삭제 배치 처리 상태 */
+	/** S3 이미지 삭제 배치 처리 상태 */
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	@Builder.Default
-	private S3CleanupStatus s3CleanupStatus = S3CleanupStatus.PENDING;
+	private S3CleanupStatus imageCleanupStatus = S3CleanupStatus.PENDING;
 
 
 	public void markDone() {
-		this.s3CleanupStatus = S3CleanupStatus.DONE;
+		this.imageCleanupStatus = S3CleanupStatus.DONE;
 	}
 
 	public void markFailed() {
-		this.s3CleanupStatus = S3CleanupStatus.FAILED;
+		this.imageCleanupStatus = S3CleanupStatus.FAILED;
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLog.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLog.java
@@ -1,0 +1,60 @@
+package com.capturecat.core.domain.user;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.capturecat.core.domain.BaseTimeEntity;
+
+@Getter
+@Entity
+@Table(name = "withdraw_log",
+	indexes = {
+		@Index(name = "idx_withdraw_log_user_id", columnList = "user_id"),
+		@Index(name = "idx_withdraw_log_created_date", columnList = "created_date"),
+		@Index(name = "idx_withdraw_log_s3_status", columnList = "s3_cleanup_status, created_date")
+	})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WithdrawLog extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long userId;
+
+	@Column(columnDefinition = "text")
+	private String reason;
+
+	/** S3 삭제 배치 처리 상태 */
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	@Builder.Default
+	private S3CleanupStatus s3CleanupStatus = S3CleanupStatus.PENDING;
+
+
+	public void markDone() {
+		this.s3CleanupStatus = S3CleanupStatus.DONE;
+	}
+
+	public void markFailed() {
+		this.s3CleanupStatus = S3CleanupStatus.FAILED;
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLogRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/WithdrawLogRepository.java
@@ -1,0 +1,6 @@
+package com.capturecat.core.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawLogRepository extends JpaRepository<WithdrawLog, Long> {
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
-import com.capturecat.core.api.user.dto.UserReqDto.JoinRespDto;
 import com.capturecat.core.api.user.dto.UserRespDto;
+import com.capturecat.core.api.user.dto.UserRespDto.JoinRespDto;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
@@ -39,6 +39,7 @@ public class UserService {
 	private final ImageTagRepository imageTagRepository;
 	private final BookmarkRepository bookmarkRepository;
 	private final SocialService socialService;
+	private final WithdrawLogService withdrawLogService;
 
 	private final PasswordEncoder passwordEncoder;
 
@@ -90,10 +91,11 @@ public class UserService {
 
 	/**
 	 * 회원 탈퇴
-	 * 모든 소셜 서비스 연결 해제 시도
-	 * 회원 관련 데이터 삭제
+	 * 1) 모든 소셜 서비스 연결 해제 시도
+	 * 2) 회원 관련 데이터 삭제
+	 * 3) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
 	 */
-	public String withdraw(LoginUser loginUser) {
+	public String withdraw(LoginUser loginUser, String reason) {
 		User user = userRepository.findByUsername(loginUser.getUsername()) //email
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
@@ -124,7 +126,14 @@ public class UserService {
 		byUser.forEach(imageTagRepository::deleteAllByImage);
 		imageRepository.deleteAll(byUser);
 
-		// 3. User 삭제 -> social account도 삭제됨
+		// 3. 탈퇴 사유 저장
+		try {
+			withdrawLogService.save(user.getId(), reason);
+		} catch (Exception e) {
+			log.error("Withdraw log save failed. userId={}", user.getId(), e);
+		}
+
+		// 4. User 삭제 -> social account도 삭제됨
 		userRepository.delete(user);
 
 		return resultMessage.toString();

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -106,7 +106,7 @@ public class UserService {
 		String resultMessage = unlinkSocials(user);
 
 		// 2. 탈퇴 사유 저장
-		saveWithdrawReason(reason, user);
+		withdrawLogService.save(user.getId(), reason);
 
 		// 3. 회원 관련 데이터 삭제
 		deleteUserAndRelated(user);
@@ -126,14 +126,6 @@ public class UserService {
 
 		// 3. User 삭제 -> social account도 삭제됨
 		userRepository.delete(user);
-	}
-
-	private void saveWithdrawReason(String reason, User user) {
-		try {
-			withdrawLogService.save(user.getId(), reason);
-		} catch (Exception e) {
-			log.error("Withdraw log save failed. userId={}", user.getId(), e);
-		}
 	}
 
 	private String unlinkSocials(User user) {

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -109,23 +109,22 @@ public class UserService {
 		withdrawLogService.save(user.getId(), reason);
 
 		// 3. 회원 관련 데이터 삭제
-		deleteUserAndRelated(user);
+		deleteUserAndRelated(user.getId());
 
 		return resultMessage;
 	}
 
 	@Transactional
-	protected void deleteUserAndRelated(User user) {
+	protected void deleteUserAndRelated(Long userId) {
 		//1. 즐겨찾기 삭제
-		bookmarkRepository.deleteByUser(user);
+		bookmarkRepository.deleteByUserId(userId);
 
-		// 2. 해당 User가 소유한 이미지 모두 삭제
-		List<Image> byUser = imageRepository.findByUser(user);
-		byUser.forEach(imageTagRepository::deleteAllByImage);
-		imageRepository.deleteAll(byUser);
+		// 2. 해당 User가 소유한 이미지모두 삭제
+		imageTagRepository.deleteAllTagsByUserId(userId);
+		imageRepository.deleteAllImagesByUserId(userId);
 
 		// 3. User 삭제 -> social account도 삭제됨
-		userRepository.delete(user);
+		userRepository.deleteById(userId);
 	}
 
 	private String unlinkSocials(User user) {

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -29,7 +29,6 @@ import com.capturecat.core.support.error.ErrorType;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class UserService {
 
@@ -46,6 +45,7 @@ public class UserService {
 	/**
 	 * 일반 회원 가입
 	 */
+	@Transactional
 	public JoinRespDto join(JoinReqDto joinReqDto) {
 		// 기 가입 여부 검사
 		if (userRepository.existsByUsername(joinReqDto.getUsername())) {
@@ -61,6 +61,7 @@ public class UserService {
 	/**
 	 * 소셜 로그인 및 신규 회원가입 처리
 	 */
+	@Transactional
 	public LoginUser upsertSocialUser(OidcUserPayload payload) {
 		User user = userSocialAccountRepository.findUserByProviderAndSocialId(payload.provider(), payload.socialId())
 			.map(UserSocialAccount::getUser)
@@ -83,6 +84,7 @@ public class UserService {
 	/**
 	 * 튜토리얼(시작하기) 완료 상태 저장
 	 */
+	@Transactional
 	public void updateTutorialCompleted(LoginUser loginUser) {
 		User user = userRepository.findByUsername(loginUser.getUsername()) //email
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
@@ -92,14 +94,49 @@ public class UserService {
 	/**
 	 * 회원 탈퇴
 	 * 1) 모든 소셜 서비스 연결 해제 시도
-	 * 2) 회원 관련 데이터 삭제
-	 * 3) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
+	 * 2) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
+	 * 3) 회원 관련 데이터 삭제
 	 */
+	@Transactional
 	public String withdraw(LoginUser loginUser, String reason) {
 		User user = userRepository.findByUsername(loginUser.getUsername()) //email
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
-		//0. 연결된 모든 소셜 로그인 해지
+		//1. 모든 소셜 서비스 연결 해제 시도
+		String resultMessage = unlinkSocials(user);
+
+		// 2. 탈퇴 사유 저장
+		saveWithdrawReason(reason, user);
+
+		// 3. 회원 관련 데이터 삭제
+		deleteUserAndRelated(user);
+
+		return resultMessage;
+	}
+
+	@Transactional
+	protected void deleteUserAndRelated(User user) {
+		//1. 즐겨찾기 삭제
+		bookmarkRepository.deleteByUser(user);
+
+		// 2. 해당 User가 소유한 이미지 모두 삭제
+		List<Image> byUser = imageRepository.findByUser(user);
+		byUser.forEach(imageTagRepository::deleteAllByImage);
+		imageRepository.deleteAll(byUser);
+
+		// 3. User 삭제 -> social account도 삭제됨
+		userRepository.delete(user);
+	}
+
+	private void saveWithdrawReason(String reason, User user) {
+		try {
+			withdrawLogService.save(user.getId(), reason);
+		} catch (Exception e) {
+			log.error("Withdraw log save failed. userId={}", user.getId(), e);
+		}
+	}
+
+	private String unlinkSocials(User user) {
 		StringBuilder resultMessage = new StringBuilder();
 		List<UserSocialAccount> socialAccounts = userSocialAccountRepository.findByUser(user);
 		for (UserSocialAccount socialAccount : socialAccounts) {
@@ -115,27 +152,7 @@ public class UserService {
 					e.getMessage());
 				resultMessage.append(msg);
 			}
-
 		}
-
-		//1. 즐겨찾기 삭제
-		bookmarkRepository.deleteByUser(user);
-
-		// 2. 해당 User가 소유한 이미지 모두 삭제
-		List<Image> byUser = imageRepository.findByUser(user);
-		byUser.forEach(imageTagRepository::deleteAllByImage);
-		imageRepository.deleteAll(byUser);
-
-		// 3. 탈퇴 사유 저장
-		try {
-			withdrawLogService.save(user.getId(), reason);
-		} catch (Exception e) {
-			log.error("Withdraw log save failed. userId={}", user.getId(), e);
-		}
-
-		// 4. User 삭제 -> social account도 삭제됨
-		userRepository.delete(user);
-
 		return resultMessage.toString();
 	}
 

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
@@ -28,6 +28,5 @@ public class WithdrawLogService {
 		} catch (Exception e) {
 			log.error("Failed to persist withdraw log. userId={}, reason={}", userId, reason, e);
 		}
-
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
@@ -5,10 +5,12 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.capturecat.core.domain.user.WithdrawLog;
 import com.capturecat.core.domain.user.WithdrawLogRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WithdrawLogService {
@@ -17,10 +19,15 @@ public class WithdrawLogService {
 	// 전파 시 실패해도 록백하지 않도록
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void save(Long userId, String reason) {
-		WithdrawLog log = WithdrawLog.builder()
-			.userId(userId)
-			.reason(reason)
-			.build();
-		withdrawLogRepository.save(log);
+		try {
+			WithdrawLog log = WithdrawLog.builder()
+				.userId(userId)
+				.reason(reason)
+				.build();
+			withdrawLogRepository.save(log);
+		} catch (Exception e) {
+			log.error("Failed to persist withdraw log. userId={}, reason={}", userId, reason, e);
+		}
+
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
@@ -14,6 +14,7 @@ import com.capturecat.core.domain.user.WithdrawLogRepository;
 public class WithdrawLogService {
 	private final WithdrawLogRepository withdrawLogRepository;
 
+	// 전파 시 실패해도 록백하지 않도록
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void save(Long userId, String reason) {
 		WithdrawLog log = WithdrawLog.builder()

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/WithdrawLogService.java
@@ -1,0 +1,25 @@
+package com.capturecat.core.service.user;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.capturecat.core.domain.user.WithdrawLog;
+import com.capturecat.core.domain.user.WithdrawLogRepository;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawLogService {
+	private final WithdrawLogRepository withdrawLogRepository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void save(Long userId, String reason) {
+		WithdrawLog log = WithdrawLog.builder()
+			.userId(userId)
+			.reason(reason)
+			.build();
+		withdrawLogRepository.save(log);
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.restassured.http.ContentType;
 
+import com.capturecat.core.api.user.dto.UserReqDto;
+import com.capturecat.core.api.user.dto.UserReqDto.WithdrawReqDto;
 import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.config.jwt.JwtUtil;
 import com.capturecat.core.domain.user.User;
@@ -63,12 +65,15 @@ class UserControllerTest extends RestDocsTest {
 	@Test
 	void 회원_탈퇴() {
 		// given
+		WithdrawReqDto requestBody = new WithdrawReqDto();
+		requestBody.setReason("test reason");
 		willReturn("소셜(google) 연결 해지 성공").given(userService).withdraw(any(LoginUser.class), any());
 
 		// when & then
 		given()
 			.header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
 			.contentType(ContentType.JSON)
+			.body(requestBody)
 			.when()
 			.delete(URL_PREFIX + "/withdraw")
 			.then()
@@ -78,6 +83,8 @@ class UserControllerTest extends RestDocsTest {
 				requestHeaders(
 					headerWithName(HttpHeaders.AUTHORIZATION)
 						.description("유효한 Access 토큰")),
+				requestFields(
+					fieldWithPath("reason").type(JsonFieldType.STRING).description("탈퇴 사유")),
 				responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과 (예: SUCCESS)"),
 					fieldWithPath("data").type(JsonFieldType.STRING).description("소셜 서비스 해지 요청 결과")

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserControllerTest.java
@@ -63,7 +63,7 @@ class UserControllerTest extends RestDocsTest {
 	@Test
 	void 회원_탈퇴() {
 		// given
-		willReturn("소셜(google) 연결 해지 성공").given(userService).withdraw(any(LoginUser.class));
+		willReturn("소셜(google) 연결 해지 성공").given(userService).withdraw(any(LoginUser.class), any());
 
 		// when & then
 		given()

--- a/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +19,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.capturecat.core.api.user.dto.UserRespDto.JoinRespDto;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
@@ -51,6 +51,9 @@ class UserServiceTest {
 
 	@Mock
 	private UserSocialAccountRepository userSocialAccountRepository;
+
+	@Mock
+	private WithdrawLogService withdrawLogService;
 
 	@Spy
 	private PasswordEncoder passwordEncoder;
@@ -107,7 +110,7 @@ class UserServiceTest {
 		when(imageRepository.findByUser(savedUser)).thenReturn(userImages);
 
 		// when
-		userService.withdraw(new LoginUser(savedUser));
+		userService.withdraw(new LoginUser(savedUser), "test reason");
 
 		// then
 		verify(bookmarkRepository).deleteByUser(savedUser);
@@ -119,6 +122,9 @@ class UserServiceTest {
 
 		// 이미지 전체 삭제
 		verify(imageRepository).deleteAll(userImages);
+
+		// 탈퇴 사유 저장
+		verify(withdrawLogService).save(savedUser.getId(), "test reason");
 
 		// 마지막으로 user 삭제
 		ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
@@ -136,10 +142,10 @@ class UserServiceTest {
 		when(userRepository.findByUsername(savedUser.getUsername())).thenReturn(Optional.empty());
 
 		// when & then
-		assertThatThrownBy(() -> userService.withdraw(new LoginUser(savedUser)))
+		assertThatThrownBy(() -> userService.withdraw(new LoginUser(savedUser), "test reason"))
 			.isInstanceOf(CoreException.class)
 			.satisfies(e -> {
-				CoreException ce = (CoreException) e;
+				CoreException ce = (CoreException)e;
 				assertThat(ce.getErrorType()).isEqualTo(ErrorType.USER_NOT_FOUND);
 			});
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/user/UserServiceTest.java
@@ -99,37 +99,23 @@ class UserServiceTest {
 		//given
 		//기 회원 만들기
 		User savedUser = newMockUser(1L);
-
 		when(userRepository.findByUsername(savedUser.getUsername())).thenReturn(Optional.of(savedUser));
-
-		// User가 소유한 이미지 2개라고 가정
-		Image image1 = mock(Image.class);
-		Image image2 = mock(Image.class);
-		List<Image> userImages = List.of(image1, image2);
-
-		when(imageRepository.findByUser(savedUser)).thenReturn(userImages);
 
 		// when
 		userService.withdraw(new LoginUser(savedUser), "test reason");
 
 		// then
-		verify(bookmarkRepository).deleteByUser(savedUser);
-		verify(imageRepository).findByUser(savedUser);
-
-		// 각 이미지에 대해 imageTagRepository.deleteAllByImage 호출
-		verify(imageTagRepository).deleteAllByImage(image1);
-		verify(imageTagRepository).deleteAllByImage(image2);
-
-		// 이미지 전체 삭제
-		verify(imageRepository).deleteAll(userImages);
-
 		// 탈퇴 사유 저장
 		verify(withdrawLogService).save(savedUser.getId(), "test reason");
 
-		// 마지막으로 user 삭제
-		ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
-		verify(userRepository).delete(captor.capture());
-		assertThat(captor.getValue()).isSameAs(savedUser);
+		// 즐겨찾기, 이미지, 회원 삭제
+		verify(bookmarkRepository).deleteByUserId(savedUser.getId());
+		verify(imageTagRepository).deleteAllTagsByUserId(savedUser.getId());
+		verify(imageRepository).deleteAllImagesByUserId(savedUser.getId());
+
+		ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+		verify(userRepository).deleteById(captor.capture());
+		assertThat(captor.getValue()).isSameAs(savedUser.getId());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #107 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 회원 탈퇴 시 탈퇴 이유를 저장한다. 
탈퇴 이유 저장에 실패해도 회원 탈퇴는 진행. 
(현 구조 상 트랜잭션 전파가 일어나지 않아 requires_new 옵션이 필요없지만, 추후 리팩토링 시 포함될 수 있으므로 옵션을 붙임)

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for users to provide a withdrawal reason when deleting their account.
  * Withdrawal reasons are now logged in a separate transaction for reliability.
  * Introduced status tracking for user image cleanup after withdrawal.

* **Improvements**
  * Enhanced withdrawal process with modular steps: unlinking social accounts, logging withdrawal reason, and deleting user data.
  * Updated API and documentation to include withdrawal reason parameter.
  * Improved data deletion by user ID for bookmarks, image tags, and images.

* **Bug Fixes**
  * Adjusted tests and documentation to align with the updated withdrawal process and new parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->