### PR TITLE
refactor: 태그 목록 조회 정렬

### DIFF
--- a/capturecat-core/src/docs/asciidoc/tag.adoc
+++ b/capturecat-core/src/docs/asciidoc/tag.adoc
@@ -3,6 +3,8 @@
 
 [[태그-목록-조회]]
 === 태그 목록 조회
+태그 목록 조회는 사용자가 최근에 사용한 태그를 기준으로 정렬합니다.
+
 ==== 성공
 operation::getTags[snippets='curl-request,http-request,query-parameters,http-response,response-fields']
 

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
@@ -8,12 +8,14 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import com.capturecat.core.domain.BaseTimeEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@ToString
 public class Tag extends BaseTimeEntity {
 
 	@Id

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -25,11 +25,12 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 	@Override
 	public Slice<Tag> searchUserTagsByUser(User user, Pageable pageable) {
 		List<Tag> tags = queryFactory
-			.selectFrom(tag)
-			.leftJoin(imageTag).on(imageTag.tag.eq(tag))
-			.leftJoin(image).on(imageTag.tag.eq(tag))
+			.select(tag)
+			.from(imageTag)
+			.join(imageTag.image, image)
+			.join(imageTag.tag, tag)
 			.where(image.user.eq(user))
-			.orderBy(tag.id.desc())
+			.orderBy(imageTag.id.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.capturecat.core.domain.tag;
 
+import static com.capturecat.core.domain.tag.TagFixture.createTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -55,6 +56,32 @@ class TagRepositoryTest {
 		image1 = imageRepository.save(DummyObject.newMockUserImage(user));
 		image2 = imageRepository.save(DummyObject.newMockUserImage(user));
 		image3 = imageRepository.save(DummyObject.newMockUserImage(user));
+	}
+
+	@Test
+	void 태그_목록_조회() {
+		// given
+		var tag1 = tagRepository.save(createTag("tag1"));
+		var tag2 = tagRepository.save(createTag("tag2"));
+		var tag3 = tagRepository.save(createTag("tag3"));
+		var tag4 = tagRepository.save(createTag("tag4"));
+		var tag5 = tagRepository.save(createTag("tag5"));
+
+		saveImageTags(image1, List.of(tag1, tag2, tag3));
+		saveImageTags(image2, List.of(tag1, tag2, tag4));
+		saveImageTags(image3, List.of(tag5));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		var tags = tagRepository.searchUserTagsByUser(user, PageRequest.of(0, 10));
+
+		// then
+		assertThat(tags.getContent()).hasSize(5);
+		assertThat(tags.hasNext()).isFalse();
+		assertThat(tags.getContent()).extracting(Tag::getName)
+			.containsExactly(tag5.getName(), tag4.getName(), tag2.getName(), tag1.getName(), tag3.getName());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #110 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그 목록 조회 정렬 기준을 수정했습니다. 제 의도는 등록된 순서대로 정렬되도록 하는 것이었는데, 태그의 아이디를 기준으로 내림차순 정렬을 하니 등록순으로 정렬이 안 되는 문제가 있어 이미지태그의 아이디를 기준으로 내림차순 정렬하도록 했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag list results are now ordered by most recently used, ensuring consistent, user-expected sorting.

* **Documentation**
  * Clarified Tag API docs to state that tag lists are sorted by the user’s recently used tags.

* **Tests**
  * Added coverage to verify tag list ordering and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->