### PR TITLE
refactor: 태그 저장과 이미지 저장 트랜잭션 분리

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/ImageRequestDto.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/image/dto/ImageRequestDto.java
@@ -1,0 +1,25 @@
+package com.capturecat.core.api.image.dto;
+
+import java.util.List;
+
+import com.capturecat.core.domain.image.dto.ImageSaveRequest;
+import com.capturecat.core.domain.tag.Tag;
+
+public class ImageRequestDto {
+
+	public record UploadItem(
+		String fileName,
+		long fileSize,
+		String captureDate,
+		List<String> tagNames
+	) {
+
+	}
+
+	public record ImageCreateData(
+		ImageSaveRequest imageSaveRequest,
+		List<Tag> tags
+	) {
+
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/Image.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/Image.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.capturecat.core.domain.BaseTimeEntity;
+import com.capturecat.core.domain.image.dto.ImageSaveRequest;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
@@ -52,6 +53,16 @@ public class Image extends BaseTimeEntity {
 		this.size = size;
 		this.captureDate = captureDate;
 		this.user = user;
+	}
+
+	public static Image create(ImageSaveRequest imageSaveRequest, User user) {
+		return Image.builder()
+			.fileName(imageSaveRequest.fileName())
+			.fileUrl(imageSaveRequest.fileUrl())
+			.size(imageSaveRequest.size())
+			.captureDate(imageSaveRequest.captureDate())
+			.user(user)
+			.build();
 	}
 
 	public void validateOwnership(User user) {

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCreator.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCreator.java
@@ -35,7 +35,7 @@ public class ImageCreator {
 	 * 이미지와 태그를 함께 저장합니다.
 	 */
 	@Transactional
-	public List<Image> save(LoginUser loginUser, List<ImageRequestDto.ImageCreateData> requests) {
+	public List<Image> createAll(LoginUser loginUser, List<ImageRequestDto.ImageCreateData> requests) {
 		User user = userRepository.findByUsername(loginUser.getUsername())
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCreator.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageCreator.java
@@ -1,0 +1,61 @@
+package com.capturecat.core.domain.image;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.capturecat.core.api.image.dto.ImageRequestDto;
+import com.capturecat.core.domain.annotation.DomainService;
+import com.capturecat.core.domain.tag.ImageTag;
+import com.capturecat.core.domain.tag.ImageTagFactory;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.user.User;
+import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+@DomainService
+@RequiredArgsConstructor
+public class ImageCreator {
+
+	private final UserRepository userRepository;
+	private final ImageRepository imageRepository;
+	private final ImageTagRepository imageTagRepository;
+	private final ImageTagValidator imageTagValidator;
+	private final ImageTagFactory imageTagFactory;
+
+	/**
+	 * 이미지와 태그를 함께 저장합니다.
+	 */
+	@Transactional
+	public List<Image> save(LoginUser loginUser, List<ImageRequestDto.ImageCreateData> requests) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+
+		List<Image> savedImages = imageRepository.saveAll(requests.stream()
+			.map(item -> Image.create(item.imageSaveRequest(), user))
+			.toList());
+
+		Map<String, Image> savedImagesMap = savedImages.stream()
+			.collect(Collectors.toMap(Image::getFileName, Function.identity()));
+
+		List<ImageTag> allImageTags = new ArrayList<>();
+		for (ImageRequestDto.ImageCreateData request : requests) {
+			Image image = savedImagesMap.get(request.imageSaveRequest().fileName());
+
+			imageTagValidator.validateTags(image, request.tags());
+
+			allImageTags.addAll(imageTagFactory.create(image, request.tags()));
+		}
+		imageTagRepository.saveAll(allImageTags);
+
+		return savedImages;
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageTagValidator.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/ImageTagValidator.java
@@ -1,0 +1,70 @@
+package com.capturecat.core.domain.image;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+@Component
+@RequiredArgsConstructor
+public class ImageTagValidator {
+
+	private static final int TAG_MAX_COUNT = 4;
+
+	private final ImageTagRepository imageTagRepository;
+
+	/**
+	 * 이미지에 태그를 추가하기 전 모든 유효성 규칙을 검증하는 기본 메서드입니다.
+	 */
+	public void validateTags(Image image, List<Tag> tags) {
+		validateDuplicateTags(tags);
+		validateExistingTagsOnImage(image, tags);
+		validateTagCount(image, tags);
+	}
+
+	/**
+	 * 제공된 태그 리스트 내에 중복된 태그가 있는지 확인합니다.
+	 */
+	private void validateDuplicateTags(List<Tag> tags) {
+		Set<Tag> uniqueTags = new HashSet<>(tags);
+		if (uniqueTags.size() < tags.size()) {
+			throw new CoreException(ErrorType.DUPLICATE_TAG_NAMES);
+		}
+	}
+
+	/**
+	 * 제공된 태그들이 이미지에 이미 등록되어 있는지 확인합니다.
+	 */
+	private void validateExistingTagsOnImage(Image image, List<Tag> tags) {
+		if (tags.isEmpty()) {
+			return;
+		}
+
+		if (imageTagRepository.existsByImageAndTagIn(image, tags)) {
+			throw new CoreException(ErrorType.ALREADY_REGISTERED_TAGS);
+		}
+	}
+
+	/**
+	 * 이미지에 추가될 태그의 개수 관련 규칙만 검증합니다.
+	 */
+	private void validateTagCount(Image image, List<Tag> tags) {
+		int newTagsCount = tags.size();
+		if (newTagsCount > TAG_MAX_COUNT) {
+			throw new CoreException(ErrorType.TOO_MANY_TAGS);
+		}
+
+		long existingTagCount = imageTagRepository.countByImage(image);
+		if (existingTagCount + newTagsCount > TAG_MAX_COUNT) {
+			throw new CoreException(ErrorType.TOO_MANY_TAGS);
+		}
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/image/dto/ImageSaveRequest.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/image/dto/ImageSaveRequest.java
@@ -1,0 +1,15 @@
+package com.capturecat.core.domain.image.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record ImageSaveRequest(
+	String fileName,
+	String fileUrl,
+	long size,
+	LocalDate captureDate,
+	List<String> tagNames) {
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -24,6 +24,8 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 
 	boolean existsByTag(Tag tag);
 
+	boolean existsByImageAndTagIn(Image image, List<Tag> tags);
+
 	void deleteAllByImage(Image image);
 
 	@Modifying

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/Tag.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -16,6 +17,7 @@ import com.capturecat.core.domain.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
+@EqualsAndHashCode(of = "id", callSuper = false)
 public class Tag extends BaseTimeEntity {
 
 	@Id

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -101,7 +101,7 @@ public class ImageService {
 		imageTagRepository.saveAll(allImageTags);
 	}
 
-	public void save(List<ImageRequestDto.UploadItem> uploadItems, LoginUser loginUser) {
+	public void createImages(List<ImageRequestDto.UploadItem> uploadItems, LoginUser loginUser) {
 		// 1. 태그 등록
 		List<String> allTagNames = uploadItems.stream()
 			.flatMap(item -> item.tagNames().stream())
@@ -131,7 +131,7 @@ public class ImageService {
 			}).toList();
 
 		// 3. 이미지 및 이미지 태그 저장
-		imageCreator.save(loginUser, requests);
+		imageCreator.createAll(loginUser, requests);
 
 		// TODO: 응답 리턴(생성된 이미지 + pre-signed URL)
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/image/ImageService.java
@@ -2,6 +2,9 @@ package com.capturecat.core.service.image;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -14,11 +17,14 @@ import lombok.RequiredArgsConstructor;
 import com.capturecat.client.upload.DeleteException;
 import com.capturecat.client.upload.FileUploader;
 import com.capturecat.client.upload.UploadException;
+import com.capturecat.core.api.image.dto.ImageRequestDto;
 import com.capturecat.core.api.image.dto.UploadItemRequest;
 import com.capturecat.core.domain.bookmark.Bookmark;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
+import com.capturecat.core.domain.image.ImageCreator;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.image.dto.ImageSaveRequest;
 import com.capturecat.core.domain.tag.ImageTag;
 import com.capturecat.core.domain.tag.ImageTagFactory;
 import com.capturecat.core.domain.tag.ImageTagRepository;
@@ -48,6 +54,7 @@ public class ImageService {
 	private final TagRepository tagRepository;
 	private final UserRepository userRepository;
 	private final BookmarkRepository bookmarkRepository;
+	private final ImageCreator imageCreator;
 
 	@Transactional
 	// TODO: UploadItemRequest의 api 패키지 의존성 제거 고민하기 및 트랜잭션 분리
@@ -92,6 +99,41 @@ public class ImageService {
 			allImageTags.addAll(imageTagFactory.create(savedImage, result));
 		}
 		imageTagRepository.saveAll(allImageTags);
+	}
+
+	public void save(List<ImageRequestDto.UploadItem> uploadItems, LoginUser loginUser) {
+		// 1. 태그 등록
+		List<String> allTagNames = uploadItems.stream()
+			.flatMap(item -> item.tagNames().stream())
+			.distinct()
+			.toList();
+
+		Map<String, Tag> registeredTags = tagRegister.registerTagsFor(allTagNames).stream()
+			.collect(Collectors.toMap(Tag::getName, Function.identity()));
+
+		// 2. 이미지 정보와 태그 엔티티 매핑
+		List<ImageRequestDto.ImageCreateData> requests = uploadItems.stream()
+			.map(each -> {
+				// TODO: Pre-signed URL 및 fileURL 생성 필요
+				ImageSaveRequest imageSaveRequest = ImageSaveRequest.builder()
+					.fileName(each.fileName())
+					.fileUrl("")
+					.size(each.fileSize())
+					.captureDate(DateTimeConverter.convert(each.captureDate()))
+					.tagNames(each.tagNames())
+					.build();
+
+				List<Tag> tags = each.tagNames().stream()
+					.map(registeredTags::get)
+					.toList();
+
+				return new ImageRequestDto.ImageCreateData(imageSaveRequest, tags);
+			}).toList();
+
+		// 3. 이미지 및 이미지 태그 저장
+		imageCreator.save(loginUser, requests);
+
+		// TODO: 응답 리턴(생성된 이미지 + pre-signed URL)
 	}
 
 	@Transactional

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserService.java
@@ -13,7 +13,6 @@ import com.capturecat.core.api.user.dto.UserReqDto.JoinReqDto;
 import com.capturecat.core.api.user.dto.UserRespDto;
 import com.capturecat.core.api.user.dto.UserRespDto.JoinRespDto;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
-import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
 import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.user.User;
@@ -97,6 +96,7 @@ public class UserService {
 	 * 2) 탈퇴 사유 저장 - 실패해도 1,2 롤백 X (별도 TX)
 	 * 3) 회원 관련 데이터 삭제
 	 */
+	@Transactional
 	public String withdraw(LoginUser loginUser, String reason) {
 		User user = userRepository.findByUsername(loginUser.getUsername()) //email
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));

--- a/capturecat-core/src/main/java/com/capturecat/core/support/handler/CoreExceptionHandler.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/support/handler/CoreExceptionHandler.java
@@ -39,7 +39,7 @@ public class CoreExceptionHandler {
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<ApiResponse<?>> handle(MissingServletRequestParameterException ex) {
-		log.warn("Missing request parameter: {}", ex.getMessage(), ex);
+		log.warn("Missing imageSaveRequest parameter: {}", ex.getMessage(), ex);
 		return ResponseEntity.badRequest()
 			.body(ApiResponse.error(ErrorType.MISSING_PARAMETER, (Object) ex.getParameterName()));
 	}

--- a/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/DummyObject.java
@@ -50,6 +50,16 @@ public class DummyObject {
 			.build();
 	}
 
+	public static Image newMockUserImage(Long id, String fileName, User user) {
+		return Image.builder()
+			.id(id)
+			.fileName(fileName)
+			.fileUrl("testUrl1")
+			.captureDate(LocalDate.now())
+			.user(user)
+			.build();
+	}
+
 	public static List<Image> newMockImages(int fromId, int toId) {
 		return IntStream.range(fromId, toId + 1).mapToObj(i -> {
 			Image image = Image.builder().id((long)i).fileName("test" + i).fileUrl("testUrl" + i).build();

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageCreatorTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageCreatorTest.java
@@ -1,0 +1,116 @@
+package com.capturecat.core.domain.image;
+
+import static java.util.List.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.api.image.dto.ImageRequestDto;
+import com.capturecat.core.domain.image.dto.ImageSaveRequest;
+import com.capturecat.core.domain.tag.ImageTag;
+import com.capturecat.core.domain.tag.ImageTagFactory;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.user.User;
+import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
+import com.capturecat.core.support.error.CoreException;
+
+@ExtendWith(MockitoExtension.class) // Mockito 기능을 JUnit 5에서 사용
+class ImageCreatorTest {
+
+	@InjectMocks // 테스트 대상 클래스. @Mock으로 선언된 객체들이 자동으로 주입됩니다.
+	private ImageCreator imageCreator;
+
+	@Mock // 가짜 객체로 만들 의존성들
+	private UserRepository userRepository;
+	@Mock
+	private ImageRepository imageRepository;
+	@Mock
+	private ImageTagRepository imageTagRepository;
+	@Mock
+	private ImageTagValidator imageTagValidator;
+	@Mock
+	private ImageTagFactory imageTagFactory;
+
+	@Test
+	@DisplayName("이미지와 태그 정보 저장에 성공한다")
+	void save_success() {
+		// given
+		User user = DummyObject.newMockUser(1L);
+		LoginUser loginUser = new LoginUser(user);
+
+		Tag tag1 = new Tag("풍경");
+		Tag tag2 = new Tag("여행");
+
+		var saveRequest1 = ImageSaveRequest.builder().fileName("image1.jpg").build();
+		var saveRequest2 = ImageSaveRequest.builder().fileName("image2.jpg").build();
+
+		var createData1 = new ImageRequestDto.ImageCreateData(saveRequest1, of(tag1));
+		var createData2 = new ImageRequestDto.ImageCreateData(saveRequest2, of(tag2));
+		var requests = of(createData1, createData2);
+
+		Image savedImage1 = DummyObject.newMockUserImage(1L, "image1.jpg", user);
+		Image savedImage2 = DummyObject.newMockUserImage(2L, "image2.jpg", user);
+
+		ImageTag imageTag1 = new ImageTag(savedImage1, tag1);
+		ImageTag imageTag2 = new ImageTag(savedImage2, tag2);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(imageRepository.saveAll(anyList())).willReturn(of(savedImage1, savedImage2));
+		willDoNothing().given(imageTagValidator).validateTags(any(), anyList());
+		given(imageTagFactory.create(savedImage1, of(tag1))).willReturn(of(imageTag1));
+		given(imageTagFactory.create(savedImage2, of(tag2))).willReturn(of(imageTag2));
+
+		// when
+		List<Image> result = imageCreator.save(loginUser, requests);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).getId()).isEqualTo(1L);
+		assertThat(result.get(1).getId()).isEqualTo(2L);
+
+		verify(userRepository, times(1)).findByUsername(eq(user.getUsername()));
+		verify(imageRepository, times(1)).saveAll(anyList());
+		verify(imageTagValidator, times(2)).validateTags(any(Image.class), anyList());
+		verify(imageTagFactory, times(1)).create(savedImage1, of(tag1));
+		verify(imageTagFactory, times(1)).create(savedImage2, of(tag2));
+	}
+
+	@Test
+	@DisplayName("사용자를 찾지 못하면 CoreException 예외가 발생한다")
+	void save_fail_userNotFound() {
+		// given
+		User user = DummyObject.newMockUser(1L);
+		LoginUser loginUser = new LoginUser(user);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> imageCreator.save(loginUser, Collections.emptyList()))
+			.isInstanceOf(CoreException.class);
+
+		verify(imageRepository, never()).saveAll(anyList());
+		verify(imageTagRepository, never()).saveAll(anyList());
+	}
+}

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageCreatorTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageCreatorTest.java
@@ -55,7 +55,7 @@ class ImageCreatorTest {
 
 	@Test
 	@DisplayName("이미지와 태그 정보 저장에 성공한다")
-	void save_success() {
+	void createAll_success() {
 		// given
 		User user = DummyObject.newMockUser(1L);
 		LoginUser loginUser = new LoginUser(user);
@@ -83,7 +83,7 @@ class ImageCreatorTest {
 		given(imageTagFactory.create(savedImage2, of(tag2))).willReturn(of(imageTag2));
 
 		// when
-		List<Image> result = imageCreator.save(loginUser, requests);
+		List<Image> result = imageCreator.createAll(loginUser, requests);
 
 		// then
 		assertThat(result).hasSize(2);
@@ -99,7 +99,7 @@ class ImageCreatorTest {
 
 	@Test
 	@DisplayName("사용자를 찾지 못하면 CoreException 예외가 발생한다")
-	void save_fail_userNotFound() {
+	void createAll_fail_userNotFound() {
 		// given
 		User user = DummyObject.newMockUser(1L);
 		LoginUser loginUser = new LoginUser(user);
@@ -107,7 +107,7 @@ class ImageCreatorTest {
 		given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
 
 		// when & then
-		assertThatThrownBy(() -> imageCreator.save(loginUser, Collections.emptyList()))
+		assertThatThrownBy(() -> imageCreator.createAll(loginUser, Collections.emptyList()))
 			.isInstanceOf(CoreException.class);
 
 		verify(imageRepository, never()).saveAll(anyList());

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageTagValidatorTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/image/ImageTagValidatorTest.java
@@ -1,0 +1,109 @@
+package com.capturecat.core.domain.image;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.capturecat.core.DummyObject;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.TagFixture;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+@ExtendWith(MockitoExtension.class)
+class ImageTagValidatorTest {
+
+	@Mock
+	private ImageTagRepository imageTagRepository;
+
+	@InjectMocks
+	private ImageTagValidator imageTagValidator;
+
+	private Image image;
+
+	@BeforeEach
+	void setUp() {
+		image = DummyObject.newMockUserImage(1L, 1L);
+	}
+
+	@Test
+	void 이미지태그_검증() {
+		// given
+		var tag1 = TagFixture.createTag(1L, "tag1");
+		var tag2 = TagFixture.createTag(2L, "tag2");
+		var tag3 = TagFixture.createTag(3L, "tag3");
+		var tag4 = TagFixture.createTag(4L, "tag4");
+
+		given(imageTagRepository.existsByImageAndTagIn(any(), anyList())).willReturn(false);
+		given(imageTagRepository.countByImage(any())).willReturn(0L);
+
+		// when & then
+		assertThatNoException().isThrownBy(
+			() -> imageTagValidator.validateTags(image, List.of(tag1, tag2, tag3, tag4)));
+	}
+
+	@Test
+	void 태그가_중복되면_실패한다() {
+		// given
+		var tag1 = TagFixture.createTag(1L, "tag1");
+		var tag2 = TagFixture.createTag(1L, "tag1");
+
+		// when & then
+		assertThatThrownBy(() -> imageTagValidator.validateTags(image, List.of(tag1, tag2)))
+			.isInstanceOf(CoreException.class)
+			.hasMessageContaining(ErrorType.DUPLICATE_TAG_NAMES.getCode().getMessage());
+	}
+
+	@Test
+	void 이미_등록된_태그를_이미지태그로_등록하면_실패한다() {
+		// given
+		var tag = TagFixture.createTag(1L, "tag1");
+
+		given(imageTagRepository.existsByImageAndTagIn(any(), anyList())).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> imageTagValidator.validateTags(image, List.of(tag)))
+			.isInstanceOf(CoreException.class)
+			.hasMessageContaining(ErrorType.ALREADY_REGISTERED_TAGS.getCode().getMessage());
+	}
+
+	@Test
+	void 이미지태그_최대_등록_개수를_초과하면_실패한다() {
+		// given
+		var tag1 = TagFixture.createTag(1L, "tag1");
+		var tag2 = TagFixture.createTag(2L, "tag2");
+		var tag3 = TagFixture.createTag(3L, "tag3");
+		var tag4 = TagFixture.createTag(4L, "tag4");
+		var tag5 = TagFixture.createTag(5L, "tag5");
+		var tags = List.of(tag1, tag2, tag3, tag4, tag5);
+
+		// when & then
+		assertThatThrownBy(() -> imageTagValidator.validateTags(image, tags))
+			.isInstanceOf(CoreException.class)
+			.hasMessageContaining(ErrorType.TOO_MANY_TAGS.getCode().getMessage());
+	}
+
+	@Test
+	void 기존에_등록된_이미지태그_개수와_등록하려는_이미지태그_개수가_최대_등록_개수를_초과하면_실패한다() {
+		// given
+		var tag = TagFixture.createTag(1L, "tag1");
+
+		given(imageTagRepository.countByImage(any())).willReturn(4L);
+
+		// when & then
+		assertThatThrownBy(() -> imageTagValidator.validateTags(image, List.of(tag)))
+			.isInstanceOf(CoreException.class)
+			.hasMessageContaining(ErrorType.TOO_MANY_TAGS.getCode().getMessage());
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #116 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그 저장하는 부분과 이미지 저장하는 부분의 트랜잭션을 분리했습니다. 프론트와 같이 반영을 해야하기 때문에 우선, 사용하지 않는 메서드로 구현을 했습니다.(+ Presigned URL은 이번 배포가 아니기 때문에 다음 배포 일정을 확인하고 고려해서 우선순위를 정하겠습니다.)

1. 태그를 저장하는 로직이 도메인 서비스로 구현이 되어 있었습니다.
2. 그래서 이미지와 이미지태그를 저장하는 로직을 도메인 서비스 계층에 구현을 했습니다.
3. 위 두 로직은 각각 도메인 서비스 계층에서 트랜잭션을 가집니다.
4. 서비스 계층에서 트랜잭션이 적용되지 않습니다.

이로 인해 발생할 수 있는 문제점은 태그는 등록이 되었지만 이미지+이미지태그 등록이 실패하는 경우에는 별도의 트랜잭션이기 때문에 후속 처리가 필요해보입니다.

추가) 제가 노션 문서에 즐겨찾기 추가하는 부분을 빼먹었더라고요. 그래서 즐겨찾기 부분도 분리를 해서 별도의 API로 만들 예정인데, 이게 트랜잭션 작업 단위에서 더 좋은 설계겠죠?

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk image creation: upload multiple images in one request with file details and capture dates.
  * Automatic tag handling: registers new tags and links them to uploaded images.
  * Atomic processing: images and their tags are created together to avoid partial uploads.

* **Bug Fixes / Validation**
  * Tag validation enhanced: blocks duplicate tags, prevents adding already-attached tags, and enforces max 4 tags per image with clear errors.

* **Tests**
  * Added unit tests covering bulk creation and tag validation flows.

* **Chores**
  * Clarified a log message and made user withdrawal operate transactionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->