### PR TITLE
feat: 유저 태그 삭제 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -101,3 +101,7 @@ include::{snippets}/errorCode/getUserTags/error-codes.adoc[]
 [[유저-태그-수정]]
 === 유저 태그 수정
 include::{snippets}/errorCode/updateUserTag/error-codes.adoc[]
+
+[[유저-태그-삭제]]
+=== 유저 태그 삭제
+include::{snippets}/errorCode/deleteUserTag/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/user.adoc
+++ b/capturecat-core/src/docs/asciidoc/user.adoc
@@ -70,3 +70,13 @@ operation::updateUserTag[snippets='curl-request,http-request,request-headers,req
 유저 태그 수정이 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
 
 <<error-codes#유저-태그-수정, 유저 태그 수정 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
+[[유저-태그-삭제]]
+=== 유저 태그 삭제
+==== 성공
+operation::deleteUserTag[snippets='curl-request,http-request,request-headers,query-parameters,http-response,response-fields']
+
+==== 실패
+유저 태그 삭제가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#유저-태그-삭제, 유저 태그 삭제 API에서 발생할 수 있는 에러>>를 살펴보세요.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
@@ -3,6 +3,7 @@ package com.capturecat.core.api.user;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,5 +49,12 @@ public class UserTagController {
 		TagResponse response = userTagService.update(loginUser, request.currentTagId(), request.newTagName());
 
 		return ApiResponse.success(response);
+	}
+
+	@DeleteMapping
+	public ApiResponse<?> delete(@AuthenticationPrincipal LoginUser loginUser, @RequestParam Long tagId) {
+		userTagService.delete(loginUser, tagId);
+
+		return ApiResponse.success();
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserTagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserTagService.java
@@ -85,6 +85,18 @@ public class UserTagService {
 		return TagResponse.from(newTag);
 	}
 
+	@Transactional
+	public void delete(LoginUser loginUser, Long tagId) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		Tag tag = tagRepository.findById(tagId)
+			.orElseThrow(() -> new CoreException(ErrorType.TAG_NOT_FOUND));
+		UserTag userTag = userTagRepository.findByUserAndTag(user, tag)
+			.orElseThrow(() -> new CoreException(ErrorType.USER_TAG_NOT_FOUND));
+
+		userTagRepository.delete(userTag);
+	}
+
 	private void validate(User user, Tag tag) {
 		validateDuplicateUserTag(user, tag);
 		validateUserTagCountLimit(user);

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserErrorCodeControllerTest.java
@@ -34,4 +34,11 @@ class UserErrorCodeControllerTest extends ErrorCodeDocumentTest {
 			USER_NOT_FOUND, TAG_NOT_FOUND, USER_TAG_NOT_FOUND);
 		generateErrorDocs("errorCode/updateUserTag", errorCodeDescriptors);
 	}
+
+	@Test
+	void 유저_태그_삭제_에러_코드_문서화() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND, TAG_NOT_FOUND,
+			USER_TAG_NOT_FOUND);
+		generateErrorDocs("errorCode/deleteUserTag", errorCodeDescriptors);
+	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
@@ -117,4 +117,23 @@ class UserTagControllerTest extends RestDocsTest {
 					fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("태그 ID"),
 					fieldWithPath("data.name").type(JsonFieldType.STRING).description("태그 이름"))));
 	}
+
+	@Test
+	void 유저_태그_삭제() {
+		// given
+		BDDMockito.given(userTagService.create(any(), anyString())).willReturn(new TagResponse(1L, "java"));
+
+		// when & then
+		given()
+			.header(HttpHeaders.AUTHORIZATION, JwtUtil.BEARER_PREFIX + ACCESS_TOKEN)
+			.contentType(ContentType.JSON)
+			.queryParam("tagId", 1L)
+			.when().delete("/v1/user-tags")
+			.then().status(HttpStatus.OK)
+			.apply(document("deleteUserTag", requestPreprocessor(), responsePreprocessor(),
+				requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("유효한 Access 토큰")),
+				queryParameters(parameterWithName("tagId").description("태그 ID")),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"))));
+	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/user/UserTagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/user/UserTagServiceTest.java
@@ -230,4 +230,68 @@ class UserTagServiceTest {
 		verify(userTagRepository, never()).delete(any());
 		verify(userTagRepository, never()).save(any());
 	}
+
+	@Test
+	void 유저_태그를_삭제한다() {
+		// given
+		var user = DummyObject.newUser("test");
+		var tag = TagFixture.createTag(1L, "java");
+		var userTag = UserTagFixture.createUserTag(1L, user, tag);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(tagRepository.findById(anyLong())).willReturn(Optional.of(tag));
+		given(userTagRepository.findByUserAndTag(eq(user), eq(tag))).willReturn(Optional.of(userTag));
+
+		// when
+		userTagService.delete(new LoginUser(user), 1L);
+
+		// then
+		verify(userTagRepository, times(1)).delete(eq(userTag));
+	}
+
+	@Test
+	void 유저_태그_삭제_시_회원이_없으면_실패한다() {
+		// given
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> userTagService.delete(new LoginUser(DummyObject.newUser("test")), 1L))
+			.isInstanceOf(CoreException.class)
+			.hasMessage(ErrorType.USER_NOT_FOUND.getCode().getMessage());
+
+		verify(userTagRepository, never()).delete(any());
+	}
+
+	@Test
+	void 유저_태그_삭제_시_태그가_없으면_실패한다() {
+		// given
+		var user = DummyObject.newUser("test");
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(tagRepository.findById(anyLong())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> userTagService.delete(new LoginUser(DummyObject.newUser("test")), 1L))
+			.isInstanceOf(CoreException.class)
+			.hasMessage(ErrorType.TAG_NOT_FOUND.getCode().getMessage());
+
+		verify(userTagRepository, never()).delete(any());
+	}
+
+	@Test
+	void 유저_태그_삭제_시_유저_태그가_없으면_실패한다() {
+		// given
+		var user = DummyObject.newUser("test");
+		var tag = TagFixture.createTag(1L, "java");
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(tagRepository.findById(anyLong())).willReturn(Optional.of(tag));
+		given(userTagRepository.findByUserAndTag(eq(user), eq(tag))).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> userTagService.delete(new LoginUser(DummyObject.newUser("test")), 1L))
+			.isInstanceOf(CoreException.class);
+
+		verify(userTagRepository, never()).delete(any());
+	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #126 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

태그 설정 부분에 사용할 유저 태그 삭제 API를 구현했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now delete a user tag via the API using a DELETE request with the tag ID. Successful deletions return a standard success response.

- Documentation
  - Added user-facing guides for deleting a user tag, including request/response examples.
  - Expanded error code references for user tag deletion (e.g., user not found, tag not found, user tag not found).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->