### PR TITLE
feat: 즐겨찾기한 이미지 태그 조회 API

### DIFF
--- a/capturecat-core/src/docs/asciidoc/bookmark.adoc
+++ b/capturecat-core/src/docs/asciidoc/bookmark.adoc
@@ -21,6 +21,16 @@ operation::getBookmarkImages[snippets='curl-request,query-parameters,http-respon
 
 <<error-codes#즐겨찾기한-이미지-조회, 즐겨찾기한 이미지 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
 
+[[즐겨찾기한-이미지의-태그-조회]]
+=== 즐겨찾기한 이미지의 태그 조회
+==== 성공
+operation::getBookmarkImageTags[snippets='curl-request,query-parameters,http-response,response-fields']
+
+==== 실패
+즐겨찾기한 이미지의 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.
+
+<<error-codes#즐겨찾기한-이미지의-태그-조회, 즐겨찾기한 이미지의 태그 조회 API에서 발생할 수 있는 에러>>를 살펴보세요.
+
 [[즐겨찾기-삭제]]
 === 즐겨찾기 삭제
 ==== 성공

--- a/capturecat-core/src/docs/asciidoc/error-codes.adoc
+++ b/capturecat-core/src/docs/asciidoc/error-codes.adoc
@@ -54,6 +54,10 @@ include::{snippets}/errorCode/addBookmark/error-codes.adoc[]
 === 즐겨찾기한 이미지 조회
 include::{snippets}/errorCode/getBookmarkImages/error-codes.adoc[]
 
+[[즐겨찾기한-이미지의-태그-조회]]
+=== 즐겨찾기한 이미지의 태그 조회
+include::{snippets}/errorCode/getBookmarkImageTags/error-codes.adoc[]
+
 [[즐겨찾기-삭제]]
 === 즐겨찾기 삭제
 include::{snippets}/errorCode/deleteBookmark/error-codes.adoc[]

--- a/capturecat-core/src/docs/asciidoc/user.adoc
+++ b/capturecat-core/src/docs/asciidoc/user.adoc
@@ -54,7 +54,7 @@ operation::createUserTag[snippets='curl-request,http-request,request-headers,que
 사용자의 태그를 조회합니다.
 
 ==== 성공
-operation::getUserTags[snippets='curl-request,http-request,request-headers,http-response,response-fields']
+operation::getUserTags[snippets='curl-request,http-request,request-headers,query-parameters,http-response,response-fields']
 
 ==== 실패
 유저 태그 조회가 실패했다면 HTTP 상태 코드와 함께 <<에러-객체-형식, 에러 객체>>가 돌아옵니다.

--- a/capturecat-core/src/main/java/com/capturecat/core/api/bookmark/BookmarkController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/bookmark/BookmarkController.java
@@ -35,8 +35,9 @@ public class BookmarkController {
 	@GetMapping("/images")
 	public ApiResponse<CursorResponse<ImageWithTagsResponse>> getBookmarkImages(
 		@AuthenticationPrincipal LoginUser loginUser,
+		@RequestParam(required = false) Long tagId,
 		@PageableDefault Pageable pageable) {
-		return ApiResponse.success(bookmarkService.getBookmarkImages(loginUser, pageable));
+		return ApiResponse.success(bookmarkService.getBookmarkImages(loginUser, tagId, pageable));
 	}
 
 	@GetMapping("/tags")

--- a/capturecat-core/src/main/java/com/capturecat/core/api/bookmark/BookmarkController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/bookmark/BookmarkController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.bookmark.BookmarkService;
 import com.capturecat.core.service.image.ImageWithTagsResponse;
+import com.capturecat.core.service.image.TagResponse;
 import com.capturecat.core.support.response.ApiResponse;
 import com.capturecat.core.support.response.CursorResponse;
 
@@ -36,6 +37,14 @@ public class BookmarkController {
 		@AuthenticationPrincipal LoginUser loginUser,
 		@PageableDefault Pageable pageable) {
 		return ApiResponse.success(bookmarkService.getBookmarkImages(loginUser, pageable));
+	}
+
+	@GetMapping("/tags")
+	public ApiResponse<CursorResponse<TagResponse>> getBookmarkImageTags(
+		@AuthenticationPrincipal LoginUser loginUser,
+		@PageableDefault Pageable pageable) {
+
+		return ApiResponse.success(bookmarkService.getBookmarkImageTags(loginUser, pageable));
 	}
 
 	@DeleteMapping

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkCustomRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkCustomRepository.java
@@ -3,9 +3,10 @@ package com.capturecat.core.domain.bookmark;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.capturecat.core.domain.tag.Tag;
 import com.capturecat.core.domain.user.User;
 
 public interface BookmarkCustomRepository {
 
-	Slice<Bookmark> searchBookmarksByUser(User user, Pageable pageable);
+	Slice<Bookmark> searchBookmarksByUser(User user, Tag tag, Pageable pageable);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/bookmark/BookmarkCustomRepositoryImpl.java
@@ -2,16 +2,20 @@ package com.capturecat.core.domain.bookmark;
 
 import static com.capturecat.core.domain.bookmark.QBookmark.bookmark;
 import static com.capturecat.core.domain.image.QImage.image;
+import static com.capturecat.core.domain.tag.QImageTag.imageTag;
 
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+import com.capturecat.core.domain.tag.QTag;
+import com.capturecat.core.domain.tag.Tag;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.support.util.SliceUtil;
 
@@ -21,16 +25,25 @@ public class BookmarkCustomRepositoryImpl implements BookmarkCustomRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Slice<Bookmark> searchBookmarksByUser(User user, Pageable pageable) {
+	public Slice<Bookmark> searchBookmarksByUser(User user, Tag tag, Pageable pageable) {
 		List<Bookmark> bookmarks = queryFactory
 			.selectFrom(bookmark)
 			.join(bookmark.image, image).fetchJoin()
-			.where(bookmark.user.eq(user))
+			.leftJoin(imageTag).on(imageTag.image.eq(image))
+			.leftJoin(QTag.tag).on(imageTag.tag.eq(QTag.tag))
+			.where(bookmark.user.eq(user), eqTag(tag))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.orderBy(bookmark.id.desc())
 			.fetch();
 
 		return SliceUtil.toSlice(bookmarks, pageable);
+	}
+
+	private BooleanExpression eqTag(Tag tag) {
+		if (tag == null) {
+			return null;
+		}
+		return imageTag.tag.eq(tag);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepository.java
@@ -16,4 +16,6 @@ public interface TagCustomRepository {
 	Slice<Tag> searchMostUsedTagsByUser(User user, Pageable pageable);
 
 	List<Tag> searchByKeyword(String keyword, Long userId, int size);
+
+	Slice<Tag> searchTagsByMemberBookmark(User user, Pageable pageable);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/TagCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.capturecat.core.domain.tag;
 
+import static com.capturecat.core.domain.bookmark.QBookmark.bookmark;
 import static com.capturecat.core.domain.image.QImage.image;
 import static com.capturecat.core.domain.tag.QImageTag.imageTag;
 import static com.capturecat.core.domain.tag.QTag.tag;
@@ -13,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+import com.capturecat.core.domain.user.QUser;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.support.querydsl.CommonTagQueryConditions;
 import com.capturecat.core.support.util.SliceUtil;
@@ -86,5 +88,23 @@ public class TagCustomRepositoryImpl implements TagCustomRepository {
 			.where(image.user.id.eq(userId), tag.name.startsWithIgnoreCase(keyword))
 			.limit(size)
 			.fetch();
+	}
+
+	@Override
+	public Slice<Tag> searchTagsByMemberBookmark(User user, Pageable pageable) {
+		List<Tag> content = queryFactory
+			.select(tag)
+			.from(imageTag)
+			.join(imageTag.tag, tag)
+			.join(imageTag.image, image)
+			.join(bookmark).on(bookmark.image.eq(image))
+			.join(bookmark.user, QUser.user)
+			.where(QUser.user.eq(user))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.orderBy(imageTag.createdDate.desc())
+			.fetch();
+
+		return SliceUtil.toSlice(content, pageable);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/user/UserRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/user/UserRepository.java
@@ -8,6 +8,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByUsername(String username);
 
 	boolean existsByUsername(String username);
-
-	Optional<User> findByEmail(String email);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/bookmark/BookmarkService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/bookmark/BookmarkService.java
@@ -13,10 +13,13 @@ import com.capturecat.core.domain.bookmark.Bookmark;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.image.ImageWithTagsResponse;
+import com.capturecat.core.service.image.TagResponse;
 import com.capturecat.core.support.error.CoreException;
 import com.capturecat.core.support.error.ErrorType;
 import com.capturecat.core.support.response.CursorResponse;
@@ -29,6 +32,7 @@ public class BookmarkService {
 	private final BookmarkRepository bookmarkRepository;
 	private final ImageRepository imageRepository;
 	private final UserRepository userRepository;
+	private final TagRepository tagRepository;
 
 	@Transactional
 	public void addBookmark(Long imageId, LoginUser loginUser) {
@@ -54,6 +58,19 @@ public class BookmarkService {
 			.toList();
 
 		return CursorUtil.toCursorResponse(responses, bookmarks.hasNext(), ImageWithTagsResponse::id);
+	}
+
+	@Transactional(readOnly = true)
+	public CursorResponse<TagResponse> getBookmarkImageTags(LoginUser loginUser, Pageable pageable) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		Slice<Tag> tags = tagRepository.searchTagsByMemberBookmark(user, pageable);
+
+		List<TagResponse> responses = tags.getContent().stream()
+			.map(TagResponse::from)
+			.toList();
+
+		return CursorUtil.toCursorResponse(responses, tags.hasNext(), TagResponse::id);
 	}
 
 	@Transactional

--- a/capturecat-core/src/main/java/com/capturecat/core/service/bookmark/BookmarkService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/bookmark/BookmarkService.java
@@ -47,10 +47,11 @@ public class BookmarkService {
 	}
 
 	@Transactional(readOnly = true)
-	public CursorResponse<ImageWithTagsResponse> getBookmarkImages(LoginUser loginUser, Pageable pageable) {
+	public CursorResponse<ImageWithTagsResponse> getBookmarkImages(LoginUser loginUser, Long tagId, Pageable pageable) {
 		User user = userRepository.findByUsername(loginUser.getUsername())
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-		Slice<Bookmark> bookmarks = bookmarkRepository.searchBookmarksByUser(user, pageable);
+		Tag tag = getTagOrNull(tagId);
+		Slice<Bookmark> bookmarks = bookmarkRepository.searchBookmarksByUser(user, tag, pageable);
 
 		List<ImageWithTagsResponse> responses = bookmarks.getContent().stream()
 			.map(Bookmark::getImage)
@@ -89,5 +90,13 @@ public class BookmarkService {
 		if (bookmarkRepository.existsByUserAndImage(user, image)) {
 			throw new CoreException(ErrorType.BOOKMARK_DUPLICATION);
 		}
+	}
+
+	private Tag getTagOrNull(Long tagId) {
+		if (tagId == null) {
+			return null;
+		}
+		return tagRepository.findById(tagId)
+			.orElseThrow(() -> new CoreException(ErrorType.TAG_NOT_FOUND));
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
@@ -25,6 +25,7 @@ import io.restassured.http.ContentType;
 import com.capturecat.core.DummyObject;
 import com.capturecat.core.service.bookmark.BookmarkService;
 import com.capturecat.core.service.image.ImageWithTagsResponse;
+import com.capturecat.core.service.image.TagResponse;
 import com.capturecat.core.support.util.CursorUtil;
 import com.capturecat.test.api.RestDocsTest;
 
@@ -89,6 +90,35 @@ class BookmarkControllerTest extends RestDocsTest {
 					fieldWithPath("data.items[].url").type(JsonFieldType.STRING).description("이미지 URL"),
 					fieldWithPath("data.items[].captureDate").type(JsonFieldType.STRING).description("캡처한 날짜"),
 					fieldWithPath("data.items[].isBookmarked").type(JsonFieldType.BOOLEAN).description("즐겨찾기 여부"),
+					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
+	}
+
+	@Test
+	void 즐겨찾기한_이미지의_이미지태그를_조회한다() {
+		// given
+		BDDMockito.given(bookmarkService.getBookmarkImageTags(any(), any())).willReturn(
+			CursorUtil.toCursorResponse(List.of(new TagResponse(1L, "고양이"), new TagResponse(2L, "cat")),
+				false,
+				TagResponse::id));
+
+		// when & then
+		given().contentType(ContentType.JSON)
+			.accept(ContentType.JSON)
+			.queryParam("page", 0)
+			.queryParam("size", 10)
+			.when().get("/v1/bookmarks/tags")
+			.then().status(HttpStatus.OK).log().all()
+			.apply(document("getBookmarkImageTags", requestPreprocessor(), responsePreprocessor(),
+				queryParameters(
+					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+					parameterWithName("size").description("페이지 크기 (기본값: 10, 최대: 100)").optional()),
+				responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
+					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+					fieldWithPath("data.lastCursor").type(JsonFieldType.NUMBER).description("마지막 커서 ID"),
+					fieldWithPath("data.items").type(JsonFieldType.ARRAY).description("즐겨찾기한 이미지 태그 목록"),
+					fieldWithPath("data.items[].id").type(JsonFieldType.NUMBER).description("이미지 태그 ID"),
+					fieldWithPath("data.items[].name").type(JsonFieldType.STRING).description("이미지 태그 이름"),
 					fieldWithPath("error").type(JsonFieldType.NULL).optional().ignored())));
 	}
 

--- a/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/bookmark/BookmarkControllerTest.java
@@ -63,7 +63,7 @@ class BookmarkControllerTest extends RestDocsTest {
 	@Test
 	void 즐겨찾기한_이미지를_조회한다() {
 		// given
-		BDDMockito.given(bookmarkService.getBookmarkImages(any(), any())).willReturn(
+		BDDMockito.given(bookmarkService.getBookmarkImages(any(), any(), any())).willReturn(
 			CursorUtil.toCursorResponse(
 				List.of(ImageWithTagsResponse.from(DummyObject.newMockImage(1L))),
 				false,
@@ -79,7 +79,9 @@ class BookmarkControllerTest extends RestDocsTest {
 			.apply(document("getBookmarkImages", requestPreprocessor(), responsePreprocessor(),
 				queryParameters(
 					parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
-					parameterWithName("size").description("페이지 크기 (기본값: 10, 최대: 100)").optional()),
+					parameterWithName("size").description("페이지 크기 (기본값: 10, 최대: 100)").optional(),
+					parameterWithName("tagId").description("태그 ID (선택한 태그로 필터링)").optional()
+				),
 				responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
 					fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -1,7 +1,29 @@
 package com.capturecat.core.api.error;
 
-import static com.capturecat.core.support.error.ErrorType.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static com.capturecat.core.support.error.ErrorType.ALREADY_REGISTERED_TAGS;
+import static com.capturecat.core.support.error.ErrorType.BOOKMARK_DUPLICATION;
+import static com.capturecat.core.support.error.ErrorType.DUPLICATE_TAG_NAMES;
+import static com.capturecat.core.support.error.ErrorType.FETCH_SOCIAL_TOKEN_FAIL;
+import static com.capturecat.core.support.error.ErrorType.GENERATE_CLIENT_SECRET_FAIL;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_ACCESS_DENIED;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_DELETE_FAILED;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_TAG_NOT_FOUND;
+import static com.capturecat.core.support.error.ErrorType.IMAGE_UPLOAD_FAILED;
+import static com.capturecat.core.support.error.ErrorType.INTERNAL_SERVER_ERROR;
+import static com.capturecat.core.support.error.ErrorType.INVALID_ACCESS_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.INVALID_AUTH_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.INVALID_DATE_FORMAT;
+import static com.capturecat.core.support.error.ErrorType.INVALID_ID_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.INVALID_LOGOUT_AUTH_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.INVALID_REFRESH_TOKEN;
+import static com.capturecat.core.support.error.ErrorType.REFRESH_TOKEN_EXPIRED;
+import static com.capturecat.core.support.error.ErrorType.SOCIAL_API_ERROR;
+import static com.capturecat.core.support.error.ErrorType.TOO_MANY_TAGS;
+import static com.capturecat.core.support.error.ErrorType.UNLINK_SOCIAL_FAIL;
+import static com.capturecat.core.support.error.ErrorType.UPLOAD_METADATA_MISMATCH;
+import static com.capturecat.core.support.error.ErrorType.USER_NOT_FOUND;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import java.util.List;
 import java.util.stream.Stream;

--- a/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/error/ErrorCodeControllerTest.java
@@ -115,9 +115,14 @@ class ErrorCodeControllerTest extends RestDocsTest {
 	}
 
 	@Test
+	void 즐겨찾기한_이미지의_이미지태그_조회_에러_코드_문서() {
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
+		generateErrorDocs("errorCode/getBookmarkImageTags", errorCodeDescriptors);
+	}
+
+	@Test
 	void 이미지_즐겨찾기_삭제_에러_코드_문서() {
-		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND,
-			IMAGE_NOT_FOUND, BOOKMARK_NOT_FOUND);
+		List<ErrorCodeDescriptor> errorCodeDescriptors = generateErrorCodeDescriptors(USER_NOT_FOUND);
 		generateErrorDocs("errorCode/deleteBookmark", errorCodeDescriptors);
 	}
 

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
@@ -83,6 +83,10 @@ class UserTagControllerTest extends RestDocsTest {
 			.then().status(HttpStatus.OK)
 			.apply(document("getUserTags", requestPreprocessor(), responsePreprocessor(),
 				requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("유효한 Access 토큰")),
+				queryParameters(
+					parameterWithName("page").description("페이지 번호").optional(),
+					parameterWithName("size").description("페이지 크기").optional()
+				),
 				responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("요청 결과"),
 					fieldWithPath("data").type(JsonFieldType.OBJECT).description("커서 페이지 응답"),

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/bookmark/BookmarkRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/bookmark/BookmarkRepositoryTest.java
@@ -18,6 +18,10 @@ import com.capturecat.core.DummyObject;
 import com.capturecat.core.config.JpaAuditingConfig;
 import com.capturecat.core.config.QueryDslConfig;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.tag.ImageTag;
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.TagFixture;
+import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.UserRepository;
 
 @DataJpaTest
@@ -26,6 +30,12 @@ class BookmarkRepositoryTest {
 
 	@Autowired
 	private ImageRepository imageRepository;
+
+	@Autowired
+	private ImageTagRepository imageTagRepository;
+
+	@Autowired
+	private TagRepository tagRepository;
 
 	@Autowired
 	private UserRepository userRepository;
@@ -40,11 +50,13 @@ class BookmarkRepositoryTest {
 	void 이미지_페치조인_테스트() {
 		// given
 		var user = userRepository.save(DummyObject.newUser("test"));
+		var tag = tagRepository.save(TagFixture.createTag("tag1"));
 		var images = imageRepository.saveAll(List.of(
 			DummyObject.newMockUserImage(user),
 			DummyObject.newMockUserImage(user),
 			DummyObject.newMockUserImage(user)
 		));
+		images.forEach(img -> imageTagRepository.save(new ImageTag(img, tag)));
 		var bookmarks = images.stream()
 			.map(i -> new Bookmark(user, i))
 			.toList();
@@ -54,7 +66,7 @@ class BookmarkRepositoryTest {
 		entityManager.clear();
 
 		// when
-		Slice<Bookmark> slice = bookmarkRepository.searchBookmarksByUser(user, PageRequest.of(0, 10));
+		Slice<Bookmark> slice = bookmarkRepository.searchBookmarksByUser(user, null, PageRequest.of(0, 10));
 
 		// then
 		assertThat(slice.getContent()).hasSize(3);
@@ -62,5 +74,52 @@ class BookmarkRepositoryTest {
 
 		Bookmark firstBookmark = slice.getContent().get(0);
 		assertThat(Hibernate.isInitialized(firstBookmark.getImage())).isTrue();
+	}
+
+	@Test
+	void 태그_파라미터가_존재할_때_해당_태그_이미지만_조회된다() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("test"));
+		var tag1 = tagRepository.save(TagFixture.createTag("tag1"));
+		var tag2 = tagRepository.save(TagFixture.createTag("tag2"));
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user));
+		imageTagRepository.save(new ImageTag(image1, tag1));
+		imageTagRepository.save(new ImageTag(image2, tag2));
+		bookmarkRepository.save(new Bookmark(user, image1));
+		bookmarkRepository.save(new Bookmark(user, image2));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		Slice<Bookmark> slice = bookmarkRepository.searchBookmarksByUser(user, tag1, PageRequest.of(0, 10));
+
+		// then
+		assertThat(slice.getContent()).hasSize(1);
+		assertThat(slice.getContent().get(0).getImage().getId()).isEqualTo(image1.getId());
+	}
+
+	@Test
+	void 이미지에_태그가_없어도_즐겨찾기_조회된다() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("test"));
+		var imageWithTag = imageRepository.save(DummyObject.newMockUserImage(user));
+		var imageWithoutTag = imageRepository.save(DummyObject.newMockUserImage(user));
+		var tag = tagRepository.save(TagFixture.createTag("tag1"));
+		imageTagRepository.save(new ImageTag(imageWithTag, tag));
+		bookmarkRepository.save(new Bookmark(user, imageWithTag));
+		bookmarkRepository.save(new Bookmark(user, imageWithoutTag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		Slice<Bookmark> slice = bookmarkRepository.searchBookmarksByUser(user, null, PageRequest.of(0, 10));
+
+		// then
+		assertThat(slice.getContent()).hasSize(2);
+		assertThat(slice.getContent()).extracting(b -> b.getImage().getId())
+			.containsExactlyInAnyOrder(imageWithTag.getId(), imageWithoutTag.getId());
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/TagRepositoryTest.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.PageRequest;
 import com.capturecat.core.DummyObject;
 import com.capturecat.core.config.JpaAuditingConfig;
 import com.capturecat.core.config.QueryDslConfig;
+import com.capturecat.core.domain.bookmark.Bookmark;
+import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.Image;
 import com.capturecat.core.domain.image.ImageRepository;
 import com.capturecat.core.domain.user.User;
@@ -39,6 +41,9 @@ class TagRepositoryTest {
 	private TagRepository tagRepository;
 
 	@Autowired
+	private BookmarkRepository bookmarkRepository;
+
+	@Autowired
 	private EntityManager entityManager;
 
 	private User user;
@@ -56,6 +61,9 @@ class TagRepositoryTest {
 		image1 = imageRepository.save(DummyObject.newMockUserImage(user));
 		image2 = imageRepository.save(DummyObject.newMockUserImage(user));
 		image3 = imageRepository.save(DummyObject.newMockUserImage(user));
+
+		bookmarkRepository.save(new Bookmark(user, image1));
+		bookmarkRepository.save(new Bookmark(user, image2));
 	}
 
 	@Test
@@ -164,6 +172,25 @@ class TagRepositoryTest {
 		assertThat(tags).hasSize(2);
 		assertThat(tags).extracting(Tag::getName)
 			.containsExactlyInAnyOrder(tag1.getName(), tag3.getName());
+	}
+
+	@Test
+	void searchTagsByMemberBookmark() {
+		// given
+		var tag1 = tagRepository.save(new Tag("tag1"));
+		var tag2 = tagRepository.save(new Tag("tag2"));
+		var tag3 = tagRepository.save(new Tag("tag3"));
+
+		saveImageTags(image1, List.of(tag1));
+		saveImageTags(image2, List.of(tag2, tag3));
+
+		// when
+		var tags = tagRepository.searchTagsByMemberBookmark(user, PageRequest.of(0, 10));
+
+		// then
+		assertThat(tags.getContent()).hasSize(3);
+		assertThat(tags.getContent()).extracting(Tag::getName)
+			.containsExactlyInAnyOrder(tag1.getName(), tag2.getName(), tag3.getName());
 	}
 
 	private void saveImageTags(Image image1, List<Tag> tags) {

--- a/capturecat-core/src/test/java/com/capturecat/core/service/bookmark/BookmarkServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/bookmark/BookmarkServiceTest.java
@@ -132,11 +132,11 @@ class BookmarkServiceTest {
 		PageRequest pageRequest = PageRequest.of(0, 10);
 
 		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
-		given(bookmarkRepository.searchBookmarksByUser(eq(user), any()))
+		given(bookmarkRepository.searchBookmarksByUser(eq(user), any(), any()))
 			.willReturn(new SliceImpl<>(List.of(bookmark), pageRequest, false));
 
 		// when
-		var responses = bookmarkService.getBookmarkImages(new LoginUser(user), pageRequest);
+		var responses = bookmarkService.getBookmarkImages(new LoginUser(user), null, pageRequest);
 
 		// then
 		assertThat(responses.hasNext()).isFalse();
@@ -154,7 +154,7 @@ class BookmarkServiceTest {
 		given(userRepository.findByUsername(anyString())).willThrow(new CoreException(ErrorType.USER_NOT_FOUND));
 
 		// when & then
-		assertThatThrownBy(() -> bookmarkService.getBookmarkImages(new LoginUser(user), pageRequest))
+		assertThatThrownBy(() -> bookmarkService.getBookmarkImages(new LoginUser(user), null, pageRequest))
 			.isInstanceOf(CoreException.class);
 	}
 

--- a/capturecat-core/src/test/java/com/capturecat/core/service/bookmark/BookmarkServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/bookmark/BookmarkServiceTest.java
@@ -26,6 +26,8 @@ import com.capturecat.core.DummyObject;
 import com.capturecat.core.domain.bookmark.Bookmark;
 import com.capturecat.core.domain.bookmark.BookmarkRepository;
 import com.capturecat.core.domain.image.ImageRepository;
+import com.capturecat.core.domain.tag.TagFixture;
+import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.support.error.CoreException;
@@ -42,6 +44,9 @@ class BookmarkServiceTest {
 
 	@Mock
 	private UserRepository userRepository;
+
+	@Mock
+	private TagRepository tagRepository;
 
 	@InjectMocks
 	private BookmarkService bookmarkService;
@@ -225,5 +230,24 @@ class BookmarkServiceTest {
 			.isInstanceOf(CoreException.class);
 
 		verify(bookmarkRepository, never()).delete(any(Bookmark.class));
+	}
+
+	@Test
+	void 즐겨찾기한_이미지의_이미지태그를_조회한다() {
+		// given
+		var user = DummyObject.newMockUser(1L);
+		var image = DummyObject.newMockImage(1L);
+
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(tagRepository.searchTagsByMemberBookmark(eq(user), any()))
+			.willReturn(new SliceImpl<>(List.of(TagFixture.createTag(1L, "tag1")), PageRequest.of(0, 10), false));
+
+		// when
+		var responses = bookmarkService.getBookmarkImageTags(new LoginUser(user), PageRequest.of(0, 10));
+
+		// then
+		assertThat(responses.hasNext()).isFalse();
+		assertThat(responses.lastCursor()).isNotNull();
+		assertThat(responses.items()).hasSize(1);
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #129 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Retrieve tags for your bookmarked images via a new endpoint with cursor-based pagination.
  - Filter bookmarked images by tag using an optional tag query parameter.

- Documentation
  - Added “즐겨찾기한 이미지의 태그 조회” docs with success and error examples.
  - Updated error-code docs and user-tag docs to include query-parameter examples.

- Tests
  - Added API, service, and repository tests covering bookmark-tag retrieval and related error-code documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->