### PR TITLE
feat: 유저 태그 수정 및 삭제 시 이미지 태그 반영

### DIFF
--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import com.capturecat.core.api.user.dto.TagRenameRequest;
 import com.capturecat.core.service.auth.LoginUser;
 import com.capturecat.core.service.image.TagResponse;
+import com.capturecat.core.service.tag.ImageTagService;
 import com.capturecat.core.service.user.UserTagService;
 import com.capturecat.core.support.response.ApiResponse;
 import com.capturecat.core.support.response.CursorResponse;
@@ -27,6 +28,7 @@ import com.capturecat.core.support.response.CursorResponse;
 public class UserTagController {
 
 	private final UserTagService userTagService;
+	private final ImageTagService imageTagService;
 
 	@PostMapping
 	public ApiResponse<TagResponse> create(@AuthenticationPrincipal LoginUser loginUser, @RequestParam String tagName) {
@@ -44,9 +46,12 @@ public class UserTagController {
 	}
 
 	@PatchMapping
-	public ApiResponse<TagResponse> update(@AuthenticationPrincipal LoginUser loginUser,
-		@RequestBody TagRenameRequest request) {
+	public ApiResponse<TagResponse> update(
+		@AuthenticationPrincipal LoginUser loginUser,
+		@RequestBody TagRenameRequest request
+	) {
 		TagResponse response = userTagService.update(loginUser, request.currentTagId(), request.newTagName());
+		imageTagService.update(loginUser, request.currentTagId(), response.id());
 
 		return ApiResponse.success(response);
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/api/user/UserTagController.java
@@ -59,6 +59,7 @@ public class UserTagController {
 	@DeleteMapping
 	public ApiResponse<?> delete(@AuthenticationPrincipal LoginUser loginUser, @RequestParam Long tagId) {
 		userTagService.delete(loginUser, tagId);
+		imageTagService.delete(loginUser, tagId);
 
 		return ApiResponse.success();
 	}

--- a/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/domain/tag/ImageTagRepository.java
@@ -33,6 +33,10 @@ public interface ImageTagRepository extends JpaRepository<ImageTag, Long> {
 	void deleteByTagAndUser(Tag tag, User user);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("UPDATE ImageTag it SET it.tag.id = :newTagId WHERE it.tag.id = :oldTagId AND it.image.user.id = :userId")
+	void updateImageTagsForUser(Long userId, Long oldTagId, Long newTagId);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("DELETE FROM ImageTag it WHERE it.image.id IN (SELECT i.id FROM Image i WHERE i.user.id = :userId)")
 	void deleteAllTagsByUserId(Long userId);
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/ImageTagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/ImageTagService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
@@ -18,6 +20,7 @@ public class ImageTagService {
 
 	private final ImageTagRepository imageTagRepository;
 	private final UserRepository userRepository;
+	private final TagRepository tagRepository;
 
 	@Transactional
 	public void update(LoginUser loginUser, Long oldTagId, Long newTagId) {
@@ -25,5 +28,15 @@ public class ImageTagService {
 			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
 
 		imageTagRepository.updateImageTagsForUser(user.getId(), oldTagId, newTagId);
+	}
+
+	@Transactional
+	public void delete(LoginUser loginUser, Long tagId) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+		Tag tag = tagRepository.findById(tagId)
+			.orElseThrow(() -> new CoreException(ErrorType.TAG_NOT_FOUND));
+
+		imageTagRepository.deleteByTagAndUser(tag, user);
 	}
 }

--- a/capturecat-core/src/main/java/com/capturecat/core/service/tag/ImageTagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/tag/ImageTagService.java
@@ -1,0 +1,29 @@
+package com.capturecat.core.service.tag;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.user.User;
+import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
+import com.capturecat.core.support.error.CoreException;
+import com.capturecat.core.support.error.ErrorType;
+
+@Service
+@RequiredArgsConstructor
+public class ImageTagService {
+
+	private final ImageTagRepository imageTagRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void update(LoginUser loginUser, Long oldTagId, Long newTagId) {
+		User user = userRepository.findByUsername(loginUser.getUsername())
+			.orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+
+		imageTagRepository.updateImageTagsForUser(user.getId(), oldTagId, newTagId);
+	}
+}

--- a/capturecat-core/src/main/java/com/capturecat/core/service/user/UserTagService.java
+++ b/capturecat-core/src/main/java/com/capturecat/core/service/user/UserTagService.java
@@ -30,7 +30,7 @@ import com.capturecat.core.support.util.CursorUtil;
 @RequiredArgsConstructor
 public class UserTagService {
 
-	private static final int MAX_USER_TAG_COUNT = 30;
+	private static final int MAX_USER_TAG_COUNT = 40;
 
 	private final UserRepository userRepository;
 	private final UserTagRepository userTagRepository;

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
@@ -29,6 +29,7 @@ import io.restassured.http.ContentType;
 
 import com.capturecat.core.config.jwt.JwtUtil;
 import com.capturecat.core.service.image.TagResponse;
+import com.capturecat.core.service.tag.ImageTagService;
 import com.capturecat.core.service.user.UserTagService;
 import com.capturecat.core.support.response.CursorResponse;
 import com.capturecat.test.api.RestDocsTest;
@@ -39,11 +40,13 @@ class UserTagControllerTest extends RestDocsTest {
 
 	private UserTagController userTagController;
 	private UserTagService userTagService;
+	private ImageTagService imageTagService;
 
 	@BeforeEach
 	void setUp() {
 		userTagService = mock(UserTagService.class);
-		userTagController = new UserTagController(userTagService);
+		imageTagService = mock(ImageTagService.class);
+		userTagController = new UserTagController(userTagService, imageTagService);
 		mockMvc = mockController(userTagController);
 	}
 
@@ -101,6 +104,7 @@ class UserTagControllerTest extends RestDocsTest {
 	void 유저_태그_수정() {
 		// given
 		BDDMockito.given(userTagService.update(any(), anyLong(), anyString())).willReturn(new TagResponse(1L, "java"));
+		BDDMockito.willDoNothing().given(imageTagService).update(any(), anyLong(), anyLong());
 
 		// when & then
 		given()

--- a/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/api/user/UserTagControllerTest.java
@@ -130,6 +130,7 @@ class UserTagControllerTest extends RestDocsTest {
 	void 유저_태그_삭제() {
 		// given
 		BDDMockito.given(userTagService.create(any(), anyString())).willReturn(new TagResponse(1L, "java"));
+		BDDMockito.willDoNothing().given(imageTagService).delete(any(), anyLong());
 
 		// when & then
 		given()

--- a/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/domain/tag/ImageTagRepositoryTest.java
@@ -114,4 +114,63 @@ class ImageTagRepositoryTest {
 		assertThat(user2Result).hasSize(1);
 		assertThat(user2Result.get(0).getImage().getUser()).isEqualTo(user2);
 	}
+
+	@Test
+	void 지정한_사용자만_태그가_교체된다() {
+		// given
+		var user1 = userRepository.save(DummyObject.newUser("user1"));
+		var user2 = userRepository.save(DummyObject.newUser("user2"));
+
+		var image1 = imageRepository.save(DummyObject.newMockUserImage(user1));
+		var image2 = imageRepository.save(DummyObject.newMockUserImage(user2));
+
+		var oldTag = tagRepository.save(TagFixture.createTag("old"));
+		var newTag = tagRepository.save(TagFixture.createTag("new"));
+
+		imageTagRepository.save(new ImageTag(image1, oldTag));
+		imageTagRepository.save(new ImageTag(image2, oldTag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		imageTagRepository.updateImageTagsForUser(user1.getId(), oldTag.getId(), newTag.getId());
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		var it1 = imageTagRepository.findByImage(image1).get(0);
+		var it2 = imageTagRepository.findByImage(image2).get(0);
+
+		assertThat(it1.getTag().getId()).isEqualTo(newTag.getId());
+		assertThat(it2.getTag().getId()).isEqualTo(oldTag.getId());
+	}
+
+	@Test
+	void 태그가_없는_이미지에는_영향이_없다() {
+		// given
+		var user = userRepository.save(DummyObject.newUser("noTagUser"));
+		var imageWithNoTag = imageRepository.save(DummyObject.newMockUserImage(user));
+
+		var oldTag = tagRepository.save(TagFixture.createTag("old"));
+		var newTag = tagRepository.save(TagFixture.createTag("new"));
+
+		var imageWithTag = imageRepository.save(DummyObject.newMockUserImage(user));
+		imageTagRepository.save(new ImageTag(imageWithTag, oldTag));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		imageTagRepository.updateImageTagsForUser(user.getId(), oldTag.getId(), newTag.getId());
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		assertThat(imageTagRepository.findByImage(imageWithNoTag)).isEmpty();
+		var updated = imageTagRepository.findByImage(imageWithTag).get(0);
+		assertThat(updated.getTag().getId()).isEqualTo(newTag.getId());
+	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
@@ -16,6 +16,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
 import com.capturecat.core.service.auth.LoginUser;
@@ -29,6 +31,9 @@ class ImageTagServiceTest {
 
 	@Mock
 	UserRepository userRepository;
+
+	@Mock
+	TagRepository tagRepository;
 
 	@InjectMocks
 	ImageTagService imageTagService;
@@ -60,6 +65,53 @@ class ImageTagServiceTest {
 
 		// when / then
 		assertThrows(CoreException.class, () -> imageTagService.update(loginUser, 1L, 2L));
+		verifyNoInteractions(imageTagRepository);
+	}
+
+	@Test
+	void 삭제_사용자_태그_존재하면_레포지토리_호출한다() {
+		// given
+		LoginUser loginUser = mock(LoginUser.class);
+		when(loginUser.getUsername()).thenReturn("existingUser");
+
+		User user = mock(User.class);
+		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+
+		Tag tag = mock(Tag.class);
+		when(tagRepository.findById(10L)).thenReturn(Optional.of(tag));
+
+		// when
+		imageTagService.delete(loginUser, 10L);
+
+		// then
+		verify(imageTagRepository, times(1)).deleteByTagAndUser(tag, user);
+	}
+
+	@Test
+	void 삭제_사용자_없으면_CoreException_던진다() {
+		// given
+		LoginUser loginUser = mock(LoginUser.class);
+		when(loginUser.getUsername()).thenReturn("noUser");
+		when(userRepository.findByUsername("noUser")).thenReturn(Optional.empty());
+
+		// when / then
+		assertThrows(CoreException.class, () -> imageTagService.delete(loginUser, 1L));
+		verifyNoInteractions(imageTagRepository, tagRepository);
+	}
+
+	@Test
+	void 삭제_태그_없으면_CoreException_던진다() {
+		// given
+		LoginUser loginUser = mock(LoginUser.class);
+		when(loginUser.getUsername()).thenReturn("existingUser");
+
+		User user = mock(User.class);
+		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+
+		when(tagRepository.findById(2L)).thenReturn(Optional.empty());
+
+		// when / then
+		assertThrows(CoreException.class, () -> imageTagService.delete(loginUser, 2L));
 		verifyNoInteractions(imageTagRepository);
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
@@ -1,11 +1,12 @@
 package com.capturecat.core.service.tag;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
@@ -15,8 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.capturecat.core.DummyObject;
 import com.capturecat.core.domain.tag.ImageTagRepository;
 import com.capturecat.core.domain.tag.Tag;
+import com.capturecat.core.domain.tag.TagFixture;
 import com.capturecat.core.domain.tag.TagRepository;
 import com.capturecat.core.domain.user.User;
 import com.capturecat.core.domain.user.UserRepository;
@@ -41,47 +44,43 @@ class ImageTagServiceTest {
 	@Test
 	void 업데이트_사용자_존재하면_레포지토리_호출한다() {
 		// given
-		LoginUser loginUser = mock(LoginUser.class);
-		when(loginUser.getUsername()).thenReturn("existingUser");
+		User user = DummyObject.newMockUser(123L);
 
-		User user = mock(User.class);
-		when(user.getId()).thenReturn(123L);
-
-		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
 
 		// when
-		imageTagService.update(loginUser, 10L, 20L);
+		imageTagService.update(new LoginUser(user), 10L, 20L);
 
 		// then
-		verify(imageTagRepository, times(1)).updateImageTagsForUser(123L, 10L, 20L);
+		verify(imageTagRepository, times(1))
+			.updateImageTagsForUser(user.getId(), 10L, 20L);
 	}
 
 	@Test
 	void 업데이트_사용자_없으면_CoreException_던진다() {
 		// given
-		LoginUser loginUser = mock(LoginUser.class);
-		when(loginUser.getUsername()).thenReturn("noUser");
-		when(userRepository.findByUsername("noUser")).thenReturn(Optional.empty());
+		User user = DummyObject.newUser("noUser");
 
-		// when / then
-		assertThrows(CoreException.class, () -> imageTagService.update(loginUser, 1L, 2L));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> imageTagService.update(new LoginUser(user), 1L, 2L))
+			.isInstanceOf(CoreException.class);
 		verifyNoInteractions(imageTagRepository);
 	}
 
 	@Test
 	void 삭제_사용자_태그_존재하면_레포지토리_호출한다() {
 		// given
-		LoginUser loginUser = mock(LoginUser.class);
-		when(loginUser.getUsername()).thenReturn("existingUser");
+		User user = DummyObject.newUser("test");
 
-		User user = mock(User.class);
-		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
 
-		Tag tag = mock(Tag.class);
-		when(tagRepository.findById(10L)).thenReturn(Optional.of(tag));
+		Tag tag = TagFixture.createTag(10L, "testTag");
+		given(tagRepository.findById(anyLong())).willReturn(Optional.of(tag));
 
 		// when
-		imageTagService.delete(loginUser, 10L);
+		imageTagService.delete(new LoginUser(user), tag.getId());
 
 		// then
 		verify(imageTagRepository, times(1)).deleteByTagAndUser(tag, user);
@@ -90,28 +89,27 @@ class ImageTagServiceTest {
 	@Test
 	void 삭제_사용자_없으면_CoreException_던진다() {
 		// given
-		LoginUser loginUser = mock(LoginUser.class);
-		when(loginUser.getUsername()).thenReturn("noUser");
-		when(userRepository.findByUsername("noUser")).thenReturn(Optional.empty());
+		User user = DummyObject.newUser("noUser");
 
-		// when / then
-		assertThrows(CoreException.class, () -> imageTagService.delete(loginUser, 1L));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> imageTagService.delete(new LoginUser(user), 1L))
+			.isInstanceOf(CoreException.class);
 		verifyNoInteractions(imageTagRepository, tagRepository);
 	}
 
 	@Test
 	void 삭제_태그_없으면_CoreException_던진다() {
 		// given
-		LoginUser loginUser = mock(LoginUser.class);
-		when(loginUser.getUsername()).thenReturn("existingUser");
+		User user = DummyObject.newUser("test");
 
-		User user = mock(User.class);
-		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
+		given(tagRepository.findById(anyLong())).willReturn(Optional.empty());
 
-		when(tagRepository.findById(2L)).thenReturn(Optional.empty());
-
-		// when / then
-		assertThrows(CoreException.class, () -> imageTagService.delete(loginUser, 2L));
+		// when & then
+		assertThatThrownBy(() -> imageTagService.delete(new LoginUser(user), 2L))
+			.isInstanceOf(CoreException.class);
 		verifyNoInteractions(imageTagRepository);
 	}
 }

--- a/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/tag/ImageTagServiceTest.java
@@ -1,0 +1,66 @@
+package com.capturecat.core.service.tag;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.capturecat.core.domain.tag.ImageTagRepository;
+import com.capturecat.core.domain.user.User;
+import com.capturecat.core.domain.user.UserRepository;
+import com.capturecat.core.service.auth.LoginUser;
+import com.capturecat.core.support.error.CoreException;
+
+@ExtendWith(MockitoExtension.class)
+class ImageTagServiceTest {
+
+	@Mock
+	ImageTagRepository imageTagRepository;
+
+	@Mock
+	UserRepository userRepository;
+
+	@InjectMocks
+	ImageTagService imageTagService;
+
+	@Test
+	void 업데이트_사용자_존재하면_레포지토리_호출한다() {
+		// given
+		LoginUser loginUser = mock(LoginUser.class);
+		when(loginUser.getUsername()).thenReturn("existingUser");
+
+		User user = mock(User.class);
+		when(user.getId()).thenReturn(123L);
+
+		when(userRepository.findByUsername("existingUser")).thenReturn(Optional.of(user));
+
+		// when
+		imageTagService.update(loginUser, 10L, 20L);
+
+		// then
+		verify(imageTagRepository, times(1)).updateImageTagsForUser(123L, 10L, 20L);
+	}
+
+	@Test
+	void 업데이트_사용자_없으면_CoreException_던진다() {
+		// given
+		LoginUser loginUser = mock(LoginUser.class);
+		when(loginUser.getUsername()).thenReturn("noUser");
+		when(userRepository.findByUsername("noUser")).thenReturn(Optional.empty());
+
+		// when / then
+		assertThrows(CoreException.class, () -> imageTagService.update(loginUser, 1L, 2L));
+		verifyNoInteractions(imageTagRepository);
+	}
+}
+

--- a/capturecat-core/src/test/java/com/capturecat/core/service/user/UserTagServiceTest.java
+++ b/capturecat-core/src/test/java/com/capturecat/core/service/user/UserTagServiceTest.java
@@ -115,7 +115,7 @@ class UserTagServiceTest {
 		given(userRepository.findByUsername(anyString())).willReturn(Optional.of(user));
 		given(tagRegister.registerTagsFor(anyString())).willReturn(tag);
 		given(userTagRepository.existsByUserAndTag(eq(user), eq(tag))).willReturn(false);
-		given(userTagRepository.countByUser(eq(user))).willReturn(30L);
+		given(userTagRepository.countByUser(eq(user))).willReturn(40L);
 
 		// when & then
 		assertThatThrownBy(() -> userTagService.create(new LoginUser(DummyObject.newUser("test")), "java"))


### PR DESCRIPTION
## 📌 관련 이슈 (필수)

> 이 PR이 어떤 이슈를 해결하는지 작성해주세요. 예시: closes #123, resolves #456

- closes #134 

## 📝 작업 내용 (필수)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

유저 태그 수정 및 삭제할 때 이미지 태그에도 반영이 되도록 했습니다.

## 💬 리뷰 참고 사항 (선택)

> 리뷰어가 참고할 만한 사항이나 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag changes (rename/delete) now synchronize with image tags so tag edits are reflected across the app.
  * Increased per-user tag limit from 30 to 40.

* **Tests**
  * Added tests covering tag synchronization, batch tag reassignments, multi-user scenarios, and deletion edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->